### PR TITLE
Feat/#14 - `OAuth2` 로그인 기능과 `Jwt` 편의 기능 추가

### DIFF
--- a/.github/workflows/ci-with-gradle-and-sonar.yml
+++ b/.github/workflows/ci-with-gradle-and-sonar.yml
@@ -55,6 +55,20 @@ jobs:
         run: chmod +x ./gradlew
 
 
+      # Secret 들 test-resources 에 추가
+      - name: Set up secret yml file
+        env:
+          YAML_SECRET: ${{ secrets.SECRET_YAML }}
+          YAML_DIR: src/main/resources
+          YAML_TEST_DIR: src/test/resources
+          YAML_FILE_NAME: application-secret.yml
+        run: |
+          echo $YAML_SECRET | base64 --decode > $YAML_DIR/$YAML_FILE_NAME
+          echo $YAML_SECRET | base64 --decode > $YAML_TEST_DIR/$YAML_FILE_NAME
+          echo "YAML_SECRET has been decoded and saved to $YAML_DIR/$YAML_FILE_NAME"
+          echo "YAML_SECRET has been decoded and saved to $YAML_TEST_DIR/$YAML_FILE_NAME"
+
+
       # test 없이 그냥 build
       - name: Build with Gradle
         run: ./gradlew build -x test --build-cache

--- a/src/main/java/com/palettee/global/configs/SecurityConfig.java
+++ b/src/main/java/com/palettee/global/configs/SecurityConfig.java
@@ -1,7 +1,9 @@
 package com.palettee.global.configs;
 
+import com.palettee.global.security.oauth.*;
+import com.palettee.global.security.oauth.handler.*;
+import lombok.*;
 import org.springframework.context.annotation.*;
-import org.springframework.security.config.*;
 import org.springframework.security.config.annotation.web.builders.*;
 import org.springframework.security.config.annotation.web.configurers.*;
 import org.springframework.security.config.http.*;
@@ -10,7 +12,12 @@ import org.springframework.web.servlet.config.annotation.*;
 
 @Configuration
 @EnableWebMvc
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oauth2LoginsuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http)
@@ -25,7 +32,11 @@ public class SecurityConfig {
         // OAuth2 설정
         // CustomOAuth2 만들어지면 수정 해야됨.
         http
-                .oauth2Login(Customizer.withDefaults());
+                .oauth2Login(oauth2 ->
+                        oauth2.userInfoEndpoint(endpointConfig ->
+                                        endpointConfig.userService(customOAuth2UserService))
+                                .successHandler(oauth2LoginsuccessHandler)
+                                .failureHandler(oAuth2LoginFailureHandler));
 
         // API 별 authenticate 설정
         // 일단 permitAll

--- a/src/main/java/com/palettee/global/configs/SecurityConfig.java
+++ b/src/main/java/com/palettee/global/configs/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.palettee.global.configs;
+
+import org.springframework.context.annotation.*;
+import org.springframework.security.config.*;
+import org.springframework.security.config.annotation.web.builders.*;
+import org.springframework.security.config.annotation.web.configurers.*;
+import org.springframework.security.config.http.*;
+import org.springframework.security.web.*;
+import org.springframework.web.servlet.config.annotation.*;
+
+@Configuration
+@EnableWebMvc
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http)
+            throws Exception {
+
+        // 우리 토큰 쓰니까 아래 것들 꺼도 됨
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        // OAuth2 설정
+        // CustomOAuth2 만들어지면 수정 해야됨.
+        http
+                .oauth2Login(Customizer.withDefaults());
+
+        // API 별 authenticate 설정
+        // 일단 permitAll
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/error").permitAll()
+
+                        .requestMatchers("/").permitAll()
+
+                        .anyRequest().permitAll()
+                );
+
+        // 토큰 이용하니까 stateless session (정확히 뭔지 모르겠음..)
+        http
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS
+                        ));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/palettee/global/security/dto/GithubResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/GithubResponse.java
@@ -1,0 +1,74 @@
+package com.palettee.global.security.dto;
+
+
+import java.util.*;
+import lombok.*;
+
+/*
+참고 : https://docs.github.com/en/rest/users/users#get-the-authenticated-user
+scope : (no_scope) 면 기본적으로 읽을 수 있는 유저 정보들 다 가져옴
+
+Attributes 형태 :
+{
+    id=????,            // github 유저별 고유한 id
+    login=jbw9964,      // github 에 사용되는 유저 이름
+    name=청주는사과아님,   // github 에 사용되는 대표(?) 유저 이름
+    avatar_url          // 프로필 이미지 url
+    =https://avatars.githubusercontent.com/u/110011678?v=4,
+    email=jbw9964@gmail.com,
+    ... (개많음)
+}
+*/
+
+/**
+ * Github OAuth 용 정보 변환 {@code DTO}
+ */
+@RequiredArgsConstructor
+public class GithubResponse
+        extends OAuth2Response {
+
+    /**
+     * 사용자 가져오기 위한 Map 객체
+     */
+    private final Map<String, Object> attributes;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getProvider() {
+        return "github";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPictureUrl() {
+        return attributes.get("avatar_url").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+}

--- a/src/main/java/com/palettee/global/security/dto/GoogleResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/GoogleResponse.java
@@ -1,0 +1,68 @@
+package com.palettee.global.security.dto;
+
+/*
+참고 : https://developers.google.com/identity/openid-connect/openid-connect?hl=ko
+scope : profile, email
+
+Attributes 형태 :
+{
+    sub=?????,
+    name=정준상, given_name=준상, family_name=정,
+    picture=https://lh3.googleusercontent.com/a/ACg8ocKBMIGxmwdLOO_EYcZhIm1XQ3I4ucyQ4bAlRIuMhDw6ApLGMYf2=s96-c,
+    email=jbw9964@gmail.com,
+    email_verified=true
+}
+*/
+
+import java.util.*;
+import lombok.*;
+
+/**
+ * Google OAuth 용 정보 변환 {@code DTO}
+ */
+@RequiredArgsConstructor
+public class GoogleResponse
+        extends OAuth2Response {
+
+    private final Map<String, Object> attributes;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPictureUrl() {
+        return attributes.get("picture").toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+}

--- a/src/main/java/com/palettee/global/security/dto/OAuth2Response.java
+++ b/src/main/java/com/palettee/global/security/dto/OAuth2Response.java
@@ -1,0 +1,47 @@
+package com.palettee.global.security.dto;
+
+/**
+ * 소셜 미디어별 OAuth2 정보 변환해줄 추상 {@code DTO} 클래스
+ */
+public abstract class OAuth2Response {
+
+    /**
+     * 인증을 담당한 주체
+     * <p>
+     * > Google, Github, ...
+     */
+    public abstract String getProvider();
+
+    /**
+     * OAuth2 별 사용자의 고유 ID
+     */
+    public abstract String getProviderId();
+
+    /**
+     * OAuth2 로 제공된 사용자 이메일 주소
+     */
+    public abstract String getEmail();
+
+    /**
+     * OAuth2 로 제공된 사용자 사진 주소
+     */
+    public abstract String getPictureUrl();
+
+    /**
+     * OAuth2 로 제공된 사용자 이름
+     */
+    public abstract String getName();
+
+    /**
+     * log 찍을때 편하게 보려고 만듬
+     */
+    @Override
+    public String toString() {
+        return String.format(
+                "%s={provider=%s, providerId=%s, name=%s, email=%s, pictureUrl=%s}",
+                this.getClass().getSimpleName(),
+                getProvider(), getProviderId(),
+                getName(), getEmail(), getPictureUrl()
+        );
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/CustomJwtUtil.java
+++ b/src/main/java/com/palettee/global/security/jwt/CustomJwtUtil.java
@@ -1,0 +1,116 @@
+package com.palettee.global.security.jwt;
+
+import com.palettee.user.domain.*;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.*;
+import io.jsonwebtoken.security.SecurityException;
+import io.jsonwebtoken.security.*;
+import java.util.*;
+import javax.crypto.*;
+import lombok.extern.slf4j.*;
+
+/**
+ * Temporary, Access, Refresh 토큰 발급, 확인을 위한 클래스
+ */
+@Slf4j
+final class CustomJwtUtil {
+
+    private final SecretKey secretKey;
+
+    public CustomJwtUtil(String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(
+                Decoders.BASE64.decode(secretKey)
+        );
+    }
+
+    private static void logDebug(String s, Exception e) {
+        log.debug(s, e);
+    }
+
+    public boolean isValid(String token) {
+        try {
+            Jwts.parser().verifyWith(secretKey).build()
+                    .parse(token);
+
+            return true;
+
+        } catch (MalformedJwtException | SecurityException |
+                 ExpiredJwtException | IllegalArgumentException e) {
+            logDebug("Invalid jwt given : {}", e);
+
+            return false;
+        } catch (Exception e) {
+            logDebug("Unexpected exception occurred while validating JWT : {}", e);
+
+            return false;
+        }
+    }
+
+    public boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration()
+                .before(new Date());
+    }
+
+    /**
+     * 토큰 발급
+     *
+     * @param user          사용자 정보
+     * @param expireTimeMin 만료 시간 (분)
+     * @return {@code String} 토큰
+     */
+    public String createToken(User user, long expireTimeMin) {
+
+        Claims claims = Jwts.claims()
+                .add("userEmail", user.getEmail())
+                .add("role", user.getUserRole())
+                .build();
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + 60 * 1_000 * expireTimeMin))
+                .signWith(this.secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * 토큰에서 유저 이메일 parse 하는 메서드
+     *
+     * @throws UnsupportedJwtException  토큰키가 맞지 않을 때
+     * @throws ExpiredJwtException      토큰이 만료되었을 때
+     * @throws IllegalArgumentException 토큰이 {@code null} 이거나 이상한 공백이 있을 때
+     * @throws RequiredTypeException    파싱시 payload 속 {@code userEmail} 이 문자열이 아닐때
+     * @throws NullPointerException     payload 에 {@code userEmail} claims 가 없을 때
+     */
+    public String getEmail(String token)
+            throws UnsupportedJwtException, ExpiredJwtException,
+            IllegalArgumentException, RequiredTypeException,
+            NullPointerException {
+
+        try {
+
+            String email = Jwts.parser().verifyWith(secretKey).build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("userEmail", String.class);
+
+            if (email == null || email.isEmpty()) {
+                throw new NullPointerException("No email exists on jwt payload");
+            }
+
+            return email;
+
+        } catch (UnsupportedJwtException | IllegalArgumentException e) {
+            logDebug("Invalid jwt given : {}", e);
+
+            throw e;
+        } catch (Exception e) {
+            logDebug("Unexpected exception occurred while validating JWT : {}", e);
+
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/JwtUtils.java
+++ b/src/main/java/com/palettee/global/security/jwt/JwtUtils.java
@@ -1,0 +1,101 @@
+package com.palettee.global.security.jwt;
+
+import com.palettee.user.domain.*;
+import lombok.extern.slf4j.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.stereotype.*;
+
+/**
+ * Jwt 토큰과 관련된 {@code Component}
+ *
+ * @see CustomJwtUtil
+ */
+@Slf4j
+@Component
+public class JwtUtils {
+
+    private final CustomJwtUtil temporaryJwtUtil;
+    private final CustomJwtUtil accessJwtUtil;
+    private final CustomJwtUtil refreshJwtUtil;
+
+    private final long tempoExpireMin;
+    private final long accessExpireMin;
+    private final long refreshExpireMin;
+
+    public JwtUtils(
+            @Value("${jwt.temporary.secret}") String tempoSecret,
+            @Value("${jwt.temporary.expire-time-min}") long tempoExpireMin,
+            @Value("${jwt.access.secret}") String accessSecret,
+            @Value("${jwt.access.expire-time-min}") long accessExpireMin,
+            @Value("${jwt.refresh.secret}") String refreshSecret,
+            @Value("${jwt.refresh.expire-time-min}") long refreshExpireMin
+    ) {
+        this.temporaryJwtUtil = new CustomJwtUtil(tempoSecret);
+        this.accessJwtUtil = new CustomJwtUtil(accessSecret);
+        this.refreshJwtUtil = new CustomJwtUtil(refreshSecret);
+
+        this.tempoExpireMin = tempoExpireMin;
+        this.accessExpireMin = accessExpireMin;
+        this.refreshExpireMin = refreshExpireMin;
+    }
+
+    // 임시 토큰과 관련된 utils
+    public boolean isTemporaryTokenValid(String temporaryToken) {
+        return temporaryJwtUtil.isValid(temporaryToken);
+    }
+
+    public boolean isTemporaryTokenExpired(String temporaryToken) {
+        return temporaryJwtUtil.isExpired(temporaryToken);
+    }
+
+    public String createTemporaryToken(User user) {
+        return temporaryJwtUtil.createToken(user, tempoExpireMin);
+    }
+
+    /**
+     * @see CustomJwtUtil#getEmail(String)
+     */
+    public String getEmailFromTemporaryToken(String temporaryToken) {
+        return temporaryJwtUtil.getEmail(temporaryToken);
+    }
+
+    // access 토큰과 관련된 utils
+    public boolean isAccessTokenValid(String accessToken) {
+        return accessJwtUtil.isValid(accessToken);
+    }
+
+    public boolean isAccessTokenExpired(String accessToken) {
+        return accessJwtUtil.isExpired(accessToken);
+    }
+
+    public String createAccessToken(User user) {
+        return accessJwtUtil.createToken(user, accessExpireMin);
+    }
+
+    /**
+     * @see CustomJwtUtil#getEmail(String)
+     */
+    public String getEmailFromAccessToken(String accessToken) {
+        return accessJwtUtil.getEmail(accessToken);
+    }
+
+    // refresh 토큰과 관련된 utils
+    public boolean isRefreshTokenValid(String refreshToken) {
+        return refreshJwtUtil.isValid(refreshToken);
+    }
+
+    public boolean isRefreshTokenExpired(String refreshToken) {
+        return refreshJwtUtil.isExpired(refreshToken);
+    }
+
+    public String createRefreshToken(User user) {
+        return refreshJwtUtil.createToken(user, refreshExpireMin);
+    }
+
+    /**
+     * @see CustomJwtUtil#getEmail(String)
+     */
+    public String getEmailFromRefreshToken(String refreshToken) {
+        return refreshJwtUtil.getEmail(refreshToken);
+    }
+}

--- a/src/main/java/com/palettee/global/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/palettee/global/security/oauth/CustomOAuth2User.java
@@ -1,0 +1,51 @@
+package com.palettee.global.security.oauth;
+
+import com.palettee.global.security.oauth.handler.*;
+import com.palettee.user.domain.*;
+import java.util.*;
+import lombok.*;
+import org.springframework.security.core.*;
+import org.springframework.security.core.authority.*;
+import org.springframework.security.oauth2.core.user.*;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+
+    /**
+     * 어차피 안 쓸거라 상관 없을 듯...?
+     */
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(
+                new SimpleGrantedAuthority(
+                        user.getUserRole().toString())
+        );
+
+        return authorities;
+    }
+
+    /**
+     * {@link OAuth2LoginSuccessHandler} 에서 로그인 성공 시, 이 메서드로 로그인된 정보 가져올 수 있음.
+     */
+    @Override
+    public String getName() {
+        return user.getName();
+    }
+
+    /**
+     * 로그인 성공 시, {@link OAuth2LoginSuccessHandler} 에서 유저 정보 가져오기 위한 메서드
+     */
+    public User getUser() {
+        return user;
+    }
+
+}

--- a/src/main/java/com/palettee/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/palettee/global/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,101 @@
+package com.palettee.global.security.oauth;
+
+import com.palettee.global.security.dto.*;
+import com.palettee.user.domain.*;
+import com.palettee.user.repository.*;
+import java.util.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.security.oauth2.client.userinfo.*;
+import org.springframework.security.oauth2.core.*;
+import org.springframework.security.oauth2.core.user.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService
+        extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepo;
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest)
+            throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest
+                .getClientRegistration()
+                .getRegistrationId();
+
+        // 소셜 로그인 종류에 따라 통일된 형태 (OAuth2Response) 만들기
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        OAuth2Response oAuth2Response;
+
+        log.debug("Given attributes: {}", attributes);
+
+        if ("google".equals(registrationId)) {
+            log.info("Google OAuth2 attempted.");
+
+            oAuth2Response = new GoogleResponse(attributes);
+        } else if ("github".equals(registrationId)) {
+            log.info("Github OAuth2 attempted.");
+
+            oAuth2Response = new GithubResponse(attributes);
+        } else {
+            log.info("Unknown OAuth2 registration id : {}", registrationId);
+
+            // OAuth2LoginFailureHandler 에서 처리할 수 있게
+            // OAuth2AuthenticationException 던지기
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("400"),
+                    "지원하지 않는 소셜 미디어 입니다.");
+        }
+
+        // 소셜 종류에 따른 DTO 완성
+        log.debug("oAuth2Response: {}", oAuth2Response);
+
+        // 해당 유저가 처음 로그인 (회원가입) 하는지 확인
+        String userOauthIdentity =
+                oAuth2Response.getProvider() + " " + oAuth2Response.getProviderId();
+
+        // 이전 다른 소셜 계정으로 회원가입 했었는지 확인
+        User userFoundByEmail = userRepo.findByEmail(oAuth2Response.getEmail())
+                .orElse(null);
+
+        User userFoundByOauth = userRepository.findByOauthIdentity(userOauthIdentity)
+                .orElse(null);
+
+        // 처음 회원가입 하는 유저
+        if (userFoundByEmail == null && userFoundByOauth == null) {
+            log.info("New user trying to signup");
+            log.debug("oAuth2Response: {}", oAuth2Response);
+
+            userFoundByEmail = User.builder()
+                    .oauthIdentity(userOauthIdentity)
+                    .userRole(UserRole.REAL_NEWBIE)
+                    .email(oAuth2Response.getEmail())
+                    .imageUrl(oAuth2Response.getPictureUrl())
+                    .name(oAuth2Response.getName())
+                    .build();
+
+            // DB 에 등록 (회원가입)
+            userFoundByEmail = userRepo.save(userFoundByEmail);
+
+            log.info("New user were registered successfully.");
+        } else if (userFoundByEmail != null && userFoundByOauth == null) {
+            log.warn("Current user seems to be registered via different social accounts.");
+            log.warn("userFoundByEmail: {}", userFoundByEmail);
+
+            // OAuth2LoginFailureHandler 에서 처리할 수 있게
+            // OAuth2AuthenticationException 던지기
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("409"),
+                    "동일한 이메일 계정이 존재합니다. 다른 소셜 계정으로 로그인 하세요.");
+        }
+
+        return new CustomOAuth2User(userFoundByEmail);
+    }
+}

--- a/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,51 @@
+package com.palettee.global.security.oauth.handler;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import java.io.*;
+import java.time.*;
+import java.util.*;
+import lombok.extern.slf4j.*;
+import org.springframework.http.*;
+import org.springframework.security.core.*;
+import org.springframework.security.oauth2.core.*;
+import org.springframework.security.web.authentication.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Component
+public class OAuth2LoginFailureHandler
+        extends SimpleUrlAuthenticationFailureHandler {
+
+    /**
+     * {@link com.palettee.global.security.oauth.CustomOAuth2UserService} 에서 실패시 동작하는 handler
+     */
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException exception)
+            throws IOException, ServletException {
+
+        OAuth2AuthenticationException oAuth2AuthenticationException
+                = (OAuth2AuthenticationException) exception;
+        OAuth2Error error = oAuth2AuthenticationException.getError();
+
+        // throws 된 exception 에서 코드, 원인 뽑아내기
+        int errorCode = Integer.parseInt(error.getErrorCode());
+        String reason = oAuth2AuthenticationException.getMessage();
+
+        // 응답
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("reason", reason);
+        body.put("timestamp", Instant.now());
+
+        response.getWriter().write(body.toString());
+
+        log.warn("Handled OAuth2 login failure.");
+        log.warn("Error status : {}", errorCode);
+        log.warn("Error msg : {}", reason);
+    }
+}

--- a/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,41 @@
+package com.palettee.global.security.oauth.handler;
+
+import com.palettee.global.security.jwt.*;
+import com.palettee.global.security.oauth.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import java.io.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.security.core.*;
+import org.springframework.security.web.authentication.*;
+import org.springframework.stereotype.*;
+
+/**
+ * OAuth 로그인 성공시 실행되는 handler
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler
+        extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtils jwtUtils;
+
+    /**
+     * 로그인 성공해서 임시 토큰으로 진짜 토큰들 발급하는 {@code /token/issue?token=} API 로 redirect
+     */
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+            Authentication authentication)
+            throws IOException, ServletException {
+
+        CustomOAuth2User customUserDetail = (CustomOAuth2User) authentication.getPrincipal();
+        String temporaryToken = jwtUtils.createTemporaryToken(customUserDetail.getUser());
+
+        log.info("Temporary token issued in CustomLoginSuccessHandler - token: {}", temporaryToken);
+
+        // 임시 토큰으로 access, refresh 토큰 발급하는 endpoint 로 redirect
+        response.sendRedirect("/token/issue?token=" + temporaryToken);
+    }
+}

--- a/src/main/java/com/palettee/user/domain/User.java
+++ b/src/main/java/com/palettee/user/domain/User.java
@@ -47,30 +47,25 @@ public class User {
 
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Gathering> gatherings = new ArrayList<>();
+    private final List<Gathering> gatherings = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<PortFolio> portfolios = new ArrayList<>();
+    private final List<PortFolio> portfolios = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Likes> likes = new ArrayList<>();
+    private final List<Likes> likes = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<RelatedLink> relatedLinks = new ArrayList<>();
+    private final List<RelatedLink> relatedLinks = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    private List<Archive> archives = new ArrayList<>();
+    private final List<Archive> archives = new ArrayList<>();
 
     @Builder
     public User(
             String oauthIdentity, UserRole userRole,
             String email, String imageUrl,
-            String name, String briefIntro,
-            List<Gathering> gatherings,
-            List<PortFolio> portfolios,
-            List<Likes> likes,
-            List<RelatedLink> relatedLinks,
-            List<Archive> archives
+            String name, String briefIntro
     ) {
         this.oauthIdentity = oauthIdentity;
         this.userRole = userRole;
@@ -78,11 +73,6 @@ public class User {
         this.imageUrl = imageUrl;
         this.name = name;
         this.briefIntro = briefIntro;
-        this.gatherings = gatherings;
-        this.portfolios = portfolios;
-        this.likes = likes;
-        this.relatedLinks = relatedLinks;
-        this.archives = archives;
     }
 
     public void addGathering(Gathering gathering) {

--- a/src/main/java/com/palettee/user/domain/User.java
+++ b/src/main/java/com/palettee/user/domain/User.java
@@ -9,6 +9,10 @@ import java.util.*;
 import lombok.*;
 
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_email", columnList = "user_email"),
+        @Index(name = "idx_oauth_identity", columnList = "oauth_identity")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
@@ -16,9 +20,20 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
-    private Long userId;
+    private Long id;
 
-    @Column(name = "user_email", nullable = false)
+    /**
+     * 사용자의 소셜 로그인 정보를 담는 column
+     * <p>
+     * > {@code google 12221}, {@code github 443312} 이런 형식
+     */
+    @Column(name = "oauth_identity", length = 50, unique = true)
+    private String oauthIdentity;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+
+    @Column(name = "user_email", unique = true, nullable = false)
     private String email;
 
     @Column(name = "user_image_url")
@@ -46,6 +61,29 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Archive> archives = new ArrayList<>();
 
+    @Builder
+    public User(
+            String oauthIdentity, UserRole userRole,
+            String email, String imageUrl,
+            String name, String briefIntro,
+            List<Gathering> gatherings,
+            List<PortFolio> portfolios,
+            List<Likes> likes,
+            List<RelatedLink> relatedLinks,
+            List<Archive> archives
+    ) {
+        this.oauthIdentity = oauthIdentity;
+        this.userRole = userRole;
+        this.email = email;
+        this.imageUrl = imageUrl;
+        this.name = name;
+        this.briefIntro = briefIntro;
+        this.gatherings = gatherings;
+        this.portfolios = portfolios;
+        this.likes = likes;
+        this.relatedLinks = relatedLinks;
+        this.archives = archives;
+    }
 
     public void addGathering(Gathering gathering) {
         this.gatherings.add(gathering);

--- a/src/main/java/com/palettee/user/domain/UserRole.java
+++ b/src/main/java/com/palettee/user/domain/UserRole.java
@@ -1,0 +1,19 @@
+package com.palettee.user.domain;
+
+/**
+ * 유저 권한을 나타내는 {@code enum}
+ *
+ * <pre>
+ * {@code
+ * - REAL_NEWBIE : 회원가입 후 기본 정보조차 등록 안된 유저 (이름, 자기소개조차 안 적은 유저)
+ * - JUST_NEWBIE : 회원가입 후 포트폴리오 등록 안된 유저
+ * - OLD_NEWBIE : 회원가입 후 프로젝트 등록 안된 유저
+ * - USER : 기본 정보, 포폴, 프젝 모두 등록된 유저
+ * - ADMIN : 관리자 유저
+ * }
+ * </pre>
+ */
+public enum UserRole {
+    REAL_NEWBIE, JUST_NEWBIE,
+    OLD_NEWBIE, USER, ADMIN
+}

--- a/src/main/java/com/palettee/user/repository/UserRepository.java
+++ b/src/main/java/com/palettee/user/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package com.palettee.user.repository;
 
 import com.palettee.user.domain.*;
+import java.util.*;
 import org.springframework.data.jpa.repository.*;
 
 public interface UserRepository
         extends JpaRepository<User, Long> {
 
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByOauthIdentity(String oauthIdentity);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,24 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+  # OAuth2 settings
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: google
+            client-id: ${oauth2.google.client-id}
+            client-secret: ${oauth2.google.client-secret}
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            scope:
+              - profile
+              - email
+
+          github:
+            client-name: github
+            client-id: ${oauth2.github.client-id}
+            client-secret: ${oauth2.github.client-secret}
+            redirect-uri: http://localhost:8080/login/oauth2/code/github
+            # no scope

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,24 +6,3 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
-
-  # OAuth2 settings
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-name: google
-            client-id: ${oauth2.google.client-id}
-            client-secret: ${oauth2.google.client-secret}
-            redirect-uri: http://localhost:8080/login/oauth2/code/google
-            scope:
-              - profile
-              - email
-
-          github:
-            client-name: github
-            client-id: ${oauth2.github.client-id}
-            client-secret: ${oauth2.github.client-secret}
-            redirect-uri: http://localhost:8080/login/oauth2/code/github
-            # no scope

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,28 +12,6 @@ spring:
   profiles:
     include: secret
 
-  # OAuth2 settings
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-name: google
-            client-id: ${oauth2.google.client-id}
-            client-secret: ${oauth2.google.client-secret}
-            redirect-uri: http://localhost:8080/login/oauth2/code/google
-            scope:
-              - profile
-              - email
-
-          github:
-            client-name: github
-            client-id: ${oauth2.github.client-id}
-            client-secret: ${oauth2.github.client-secret}
-            redirect-uri: http://localhost:8080/login/oauth2/code/github
-            # no scope
-
-
 redis:
   host: localhost
   port: 6379

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,28 @@ spring:
   profiles:
     include: secret
 
+  # OAuth2 settings
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-name: google
+            client-id: ${oauth2.google.client-id}
+            client-secret: ${oauth2.google.client-secret}
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            scope:
+              - profile
+              - email
+
+          github:
+            client-name: github
+            client-id: ${oauth2.github.client-id}
+            client-secret: ${oauth2.github.client-secret}
+            redirect-uri: http://localhost:8080/login/oauth2/code/github
+            # no scope
+
+
 redis:
   host: localhost
   port: 6379


### PR DESCRIPTION
## #️⃣연관된 이슈

Close: #14 

## 📝작업 내용

- `Google`, `Github` 를 이용한 `OAuth2` 로그인 기능을 추가하였습니다.
  앱 실행 후 `localhost:8080/login` 을 통해 직접 확인할 수 있습니다.

-  `OAuth` 를 통해 성공적으로 신원이 확인 되었다면, `성공 핸들러` 를 통해 `localhost:8080/token/issue?token=???` 로 `redirect` 되도록 만들었습니다.
- 반면 확인에 실패하였다면, `실패 핸들러` 를 통해 발생한 에러를 확인, 응답하도록 `(일단)` 만들었습니다.

- `Jwt` 토큰 검증, 발급과 관련된 `JwtUtils` 클래스를 만들었습니다.
  해당 클래스는  `임시`, `access`, `refresh` 토큰을 검증, 생성, `parse` 할 수 있습니다.

아직 `Jwt` 편의 기능만 존재할 뿐, `JwtFilter` 등을 만들지 않았습니다.
해당 `PR` merge 후 추가하도록 하겠습니다.

### 스크린샷 (선택)

![캡처](https://github.com/user-attachments/assets/725bf6ad-8a18-4b6b-8c81-9bb93d68dce1)


## 💬리뷰 요구사항(선택)

