### PR TITLE
#23 - `JwtFilter`, 토큰 API 추가

### DIFF
--- a/.github/workflows/ci-with-gradle-and-sonar.yml
+++ b/.github/workflows/ci-with-gradle-and-sonar.yml
@@ -72,7 +72,14 @@ jobs:
       # test 없이 그냥 build
       - name: Build with Gradle
         run: ./gradlew build -x test --build-cache
-      
+
+
+      # Redis 활성화
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.1.0
+        with:
+          redis-version: 6
+
 
       # 테스트 실행
       - name: Run Tests

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -54,8 +57,11 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/palettee/global/configs/RedisConfig.java
+++ b/src/main/java/com/palettee/global/configs/RedisConfig.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.*;
 import org.springframework.context.annotation.*;
 import org.springframework.data.redis.connection.*;
 import org.springframework.data.redis.connection.lettuce.*;
+import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.serializer.*;
 
 @Configuration
 public class RedisConfig {
@@ -26,4 +28,13 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisConfiguration);
     }
 
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
 }

--- a/src/main/java/com/palettee/global/configs/SecurityConfig.java
+++ b/src/main/java/com/palettee/global/configs/SecurityConfig.java
@@ -1,12 +1,20 @@
 package com.palettee.global.configs;
 
+import com.palettee.global.security.jwt.filters.*;
+import com.palettee.global.security.jwt.handler.*;
+import com.palettee.global.security.jwt.utils.*;
 import com.palettee.global.security.oauth.*;
 import com.palettee.global.security.oauth.handler.*;
+import com.palettee.user.domain.*;
+import com.palettee.user.repository.*;
+import java.util.*;
 import lombok.*;
 import org.springframework.context.annotation.*;
+import org.springframework.http.*;
 import org.springframework.security.config.annotation.web.builders.*;
 import org.springframework.security.config.annotation.web.configurers.*;
 import org.springframework.security.config.http.*;
+import org.springframework.security.oauth2.client.web.*;
 import org.springframework.security.web.*;
 import org.springframework.web.servlet.config.annotation.*;
 
@@ -18,10 +26,78 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oauth2LoginsuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final JwtUtils jwtUtils;
+    private final UserRepository userRepo;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    /**
+     * {@link JwtFilter} 검증을 회피할 {@code URI} 들 {@code (HttpMethod 포함)}
+     *
+     * @return {@code Map} 의 {@code key} 값은 {@code URI} 와 {@code match} 할 수 있는 {@code regex}
+     */
+    @Bean
+    public Map<String, List<HttpMethod>> byPassableUris() {
+        final Map<String, List<HttpMethod>> uris = new HashMap<>();
+
+        // /aaa/{path}      -> /aaa/[^/]+$
+        // /aaa/{path}/bbb  -> /aaa/[^/]+/bbb
+        // /aaa?query       -> /aaa
+
+        // OAuth2
+        uris.put("/login", List.of(HttpMethod.GET));
+        uris.put("/login/oauth2/code/google", List.of(HttpMethod.GET));
+        uris.put("/login/oauth2/code/github", List.of(HttpMethod.GET));
+
+        // 토큰 발급
+        uris.put("/token/issue", List.of(HttpMethod.GET));
+        uris.put("/token/reissue", List.of(HttpMethod.POST));
+        uris.put("/token/test-test/[^/]+$", List.of(HttpMethod.GET));
+
+        // TODO : 편의용 임시 발급. 나중에 개발 다 되면 없애야 됨.
+        uris.put("/token/test-issue", List.of(HttpMethod.POST));
+
+        // 포트폴리오 전체 조회
+        uris.put("/portfolio", List.of(HttpMethod.GET));
+
+        // 메인 인기 포트폴리오 페이지
+        uris.put("/main/portfolio", List.of(HttpMethod.GET));
+
+        // 소모임 전체 조회
+        uris.put("/gathering", List.of(HttpMethod.GET));
+
+        // 아카이브 전체, 단건 조회
+        uris.put("/archive", List.of(HttpMethod.GET));
+        uris.put("^/archive/[^/]+$", List.of(HttpMethod.GET));
+
+        // 아카이브 검색, 댓글 조회
+        uris.put("/archive/search", List.of(HttpMethod.GET));
+        uris.put("/archive/[^/]+/comment", List.of(HttpMethod.GET));
+
+        return uris;
+    }
+
+    /**
+     * {@link JwtFilter} 검증에 특수한 처리가 필요한 {@code URI} 들 {@code (HttpMethod 포함)}
+     *
+     * @return {@code Map} 의 {@code key} 값은 {@code URI} 와 {@code match} 할 수 있는 {@code regex}
+     */
+    @Bean
+    public Map<String, List<HttpMethod>> conditionalAuthUris() {
+        final Map<String, List<HttpMethod>> uris = new HashMap<>();
+
+        // 유저 프로필 정보 조회
+        uris.put("/user/[^/]+/profile", List.of(HttpMethod.GET));
+
+        return uris;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http)
             throws Exception {
+
+        String[] aboveJustNewbie = new String[]{
+                UserRole.OLD_NEWBIE.toString(), UserRole.USER.toString(), UserRole.ADMIN.toString()
+        };
 
         // 우리 토큰 쓰니까 아래 것들 꺼도 됨
         http
@@ -30,7 +106,6 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable);
 
         // OAuth2 설정
-        // CustomOAuth2 만들어지면 수정 해야됨.
         http
                 .oauth2Login(oauth2 ->
                         oauth2.userInfoEndpoint(endpointConfig ->
@@ -39,14 +114,89 @@ public class SecurityConfig {
                                 .failureHandler(oAuth2LoginFailureHandler));
 
         // API 별 authenticate 설정
-        // 일단 permitAll
         http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/error").permitAll()
+                        .requestMatchers("/error")
+                        .permitAll()
 
-                        .requestMatchers("/").permitAll()
+                        /* <-------------- User API --------------> */
+                        // 토큰 발급
+                        .requestMatchers("/token/issue", "/token/reissue")
+                        .permitAll()
 
-                        .anyRequest().permitAll()
+                        // 유저 정보 입력 폼 관련
+                        .requestMatchers("/profile", "/project")
+                        .authenticated()
+                        .requestMatchers(HttpMethod.POST, "/portfolio")
+                        .authenticated()
+
+                        // 유저 정보 수정
+                        .requestMatchers("/user/{id}/edit")
+                        .authenticated()
+
+                        /* <-------------- Portfolio API --------------> */
+                        // 포폴 세부 조회
+                        .requestMatchers("/portfolio/{portfolioId}")
+                        .hasAnyRole(aboveJustNewbie)
+
+                        // 자신이 좋아요, 북마크한 포폴 조회
+                        .requestMatchers("/mypage/like-portfolios")
+                        .authenticated()
+
+                        // 포트폴리오 좋아요 누루기
+                        .requestMatchers("/portfolio/likes")
+                        .authenticated()
+
+                        // 소모임 자기가 생성
+                        .requestMatchers(HttpMethod.POST, "/gathering")
+                        .hasAnyRole(aboveJustNewbie)
+
+                        // 소모임 상세 정보 조회
+                        .requestMatchers("/gathering/{gatheringId}")
+                        .hasAnyRole(aboveJustNewbie)
+
+                        /* <-------------- Chat API --------------> */
+                        .requestMatchers("/chat-room")
+                        .hasAnyRole(aboveJustNewbie)
+                        .requestMatchers("/chat-room/**")
+                        .hasAnyRole(aboveJustNewbie)
+                        .requestMatchers("/chat/**")
+                        .hasAnyRole(aboveJustNewbie)
+                        .requestMatchers("/chat-img/**")
+                        .hasAnyRole(aboveJustNewbie)
+                        .requestMatchers("/ws")
+                        .hasAnyRole(aboveJustNewbie)
+
+                        /* <-------------- Archive API --------------> */
+                        // 아카이브 생성
+                        .requestMatchers(HttpMethod.POST, "/archive")
+                        .authenticated()
+
+                        // 나의 아카이브 조회 & 내가 좋아요한 아카이브 조회
+                        .requestMatchers("/archive/me")
+                        .authenticated()
+                        .requestMatchers("/archive/me/like")
+                        .authenticated()
+
+                        // 아카이브 수정, 삭제, 순서 변경
+                        .requestMatchers("/archive/{archiveId}")
+                        .authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/archive")
+                        .authenticated()
+
+                        // 댓글 작성, 삭제
+                        .requestMatchers(HttpMethod.POST, "/archive/{archiveId}/comment")
+                        .authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/archive/{archiveId}/comment")
+                        .authenticated()
+
+                        // 알림 조회, 생성, 확인
+                        .requestMatchers("/notification/**")
+                        .authenticated()
+
+                        /* <-------------- Other API --------------> */
+                        .anyRequest()
+                        .permitAll()
                 );
 
         // 토큰 이용하니까 stateless session (정확히 뭔지 모르겠음..)

--- a/src/main/java/com/palettee/global/configs/SwaggerConfig.java
+++ b/src/main/java/com/palettee/global/configs/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.palettee.global.configs;
+
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.info.*;
+import io.swagger.v3.oas.models.security.*;
+import org.springframework.context.annotation.*;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // Swagger 에서 JWT 이용 가능하도록 추가 설정
+        String jwt = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat(jwt)
+        );
+
+        return new OpenAPI()
+                .components(components)
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("API Documentation")
+                .description("API Documentation")
+                .version("0.0.1");
+    }
+
+}

--- a/src/main/java/com/palettee/global/exception/ErrorCode.java
+++ b/src/main/java/com/palettee/global/exception/ErrorCode.java
@@ -1,8 +1,6 @@
 package com.palettee.global.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.springframework.http.HttpStatus;
+import lombok.*;
 
 @Getter
 @AllArgsConstructor
@@ -11,6 +9,12 @@ public enum ErrorCode {
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     INVALID_TOKEN(401, "토큰이 유효하지 않습니다."), // 예시
+
+    /* token 관련 error code */
+    EXPIRED_TOKEN(401, "토큰이 만료되었습니다."),
+    NO_TOKEN_EXISTS(401, "토큰이 존재하지 않습니다."),
+    ROLE_MISMATCH(403, "권한이 부족합니다."),
+    NO_USER_FOUND_VIA_TOKEN(404, "토큰으로 유저를 찾지 못했습니다."),
 
     /* 403 UNAUTHORIZED : 인증되지 않은 사용자 */
 

--- a/src/main/java/com/palettee/global/exception/ErrorCode.java
+++ b/src/main/java/com/palettee/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
     /* 400 BAD_REQUEST : 잘못된 요청 */
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
-    INVALID_TOKEN(401, "토큰이 유효하지 않습니다."), // 예시
+    INVALID_TOKEN(400, "토큰이 유효하지 않습니다."), // 예시
 
     /* token 관련 error code */
     EXPIRED_TOKEN(401, "토큰이 만료되었습니다."),
@@ -21,9 +21,8 @@ public enum ErrorCode {
     /* 404 NOT_FOUND : Resource를 찾을 수 없음 */
 
     /* 500 */
-    INTERNAL_SERVER_ERROR(500,"서버 에러")
-    ;
+    INTERNAL_SERVER_ERROR(500, "서버 에러");
 
-    private int status;
-    private String reason;
+    private final int status;
+    private final String reason;
 }

--- a/src/main/java/com/palettee/global/redis/RedisService.java
+++ b/src/main/java/com/palettee/global/redis/RedisService.java
@@ -25,6 +25,11 @@ public class RedisService {
      */
     public void storeRefreshToken(final User user, final String refreshToken, long expireMin) {
         String key = getRefreshTokenKey(user);
+
+        if (this.getRefreshToken(user).isPresent()) {
+            deleteRefreshToken(user);
+        }
+
         redisTemplate.opsForValue().set(key, refreshToken, expireMin, TimeUnit.MINUTES);
 
         log.info("Refresh token has been stored to redis : {}", key);
@@ -41,6 +46,8 @@ public class RedisService {
     public void deleteRefreshToken(final User user) {
         String key = getRefreshTokenKey(user);
         redisTemplate.delete(key);
+
+        log.info("Deleted user {} refresh token.", user.getEmail());
     }
 
     private String getRefreshTokenKey(final User user) {

--- a/src/main/java/com/palettee/global/redis/RedisService.java
+++ b/src/main/java/com/palettee/global/redis/RedisService.java
@@ -7,7 +7,6 @@ import lombok.*;
 import lombok.extern.slf4j.*;
 import org.springframework.data.redis.core.*;
 import org.springframework.stereotype.*;
-import org.springframework.transaction.annotation.*;
 
 @Slf4j
 @Service
@@ -24,7 +23,6 @@ public class RedisService {
      * @param user      {@code Refresh} 토큰을 발급한 유저
      * @param expireMin {@code Refresh} 토큰 만료 시간 (분)
      */
-    @Transactional
     public void storeRefreshToken(final User user, final String refreshToken, long expireMin) {
         String key = getRefreshTokenKey(user);
         redisTemplate.opsForValue().set(key, refreshToken, expireMin, TimeUnit.MINUTES);
@@ -35,13 +33,11 @@ public class RedisService {
     /**
      * 유저가 발급했던 {@code Refresh} 토큰 가져오는 메서드
      */
-    @Transactional(readOnly = true)
     public Optional<String> getRefreshToken(final User user) {
         String key = getRefreshTokenKey(user);
         return Optional.ofNullable((String) redisTemplate.opsForValue().get(key));
     }
 
-    @Transactional
     public void deleteRefreshToken(final User user) {
         String key = getRefreshTokenKey(user);
         redisTemplate.delete(key);

--- a/src/main/java/com/palettee/global/redis/RedisService.java
+++ b/src/main/java/com/palettee/global/redis/RedisService.java
@@ -1,0 +1,53 @@
+package com.palettee.global.redis;
+
+import com.palettee.user.domain.*;
+import java.util.*;
+import java.util.concurrent.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.data.redis.core.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    public final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * {@code Refresh} 토큰 저장하기 위한 메서드
+     * <p>
+     * 값 저장할 때 {@code timeout} 넣어줘서 {@code Redis} 가 알아서 나중에 삭제해줌
+     *
+     * @param user      {@code Refresh} 토큰을 발급한 유저
+     * @param expireMin {@code Refresh} 토큰 만료 시간 (분)
+     */
+    @Transactional
+    public void storeRefreshToken(final User user, final String refreshToken, long expireMin) {
+        String key = getRefreshTokenKey(user);
+        redisTemplate.opsForValue().set(key, refreshToken, expireMin, TimeUnit.MINUTES);
+
+        log.info("Refresh token has been stored to redis : {}", key);
+    }
+
+    /**
+     * 유저가 발급했던 {@code Refresh} 토큰 가져오는 메서드
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> getRefreshToken(final User user) {
+        String key = getRefreshTokenKey(user);
+        return Optional.ofNullable((String) redisTemplate.opsForValue().get(key));
+    }
+
+    @Transactional
+    public void deleteRefreshToken(final User user) {
+        String key = getRefreshTokenKey(user);
+        redisTemplate.delete(key);
+    }
+
+    private String getRefreshTokenKey(final User user) {
+        return "refresh_token_" + user.getEmail();
+    }
+}

--- a/src/main/java/com/palettee/global/security/dto/oauth/GithubResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/oauth/GithubResponse.java
@@ -1,4 +1,4 @@
-package com.palettee.global.security.dto;
+package com.palettee.global.security.dto.oauth;
 
 
 import java.util.*;

--- a/src/main/java/com/palettee/global/security/dto/oauth/GoogleResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/oauth/GoogleResponse.java
@@ -1,4 +1,4 @@
-package com.palettee.global.security.dto;
+package com.palettee.global.security.dto.oauth;
 
 /*
 참고 : https://developers.google.com/identity/openid-connect/openid-connect?hl=ko

--- a/src/main/java/com/palettee/global/security/dto/oauth/OAuth2FailureResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/oauth/OAuth2FailureResponse.java
@@ -1,0 +1,7 @@
+package com.palettee.global.security.dto.oauth;
+
+import java.time.*;
+
+public record OAuth2FailureResponse(int status, String reason, LocalDateTime timeStamp) {
+
+}

--- a/src/main/java/com/palettee/global/security/dto/oauth/OAuth2Response.java
+++ b/src/main/java/com/palettee/global/security/dto/oauth/OAuth2Response.java
@@ -1,4 +1,4 @@
-package com.palettee.global.security.dto;
+package com.palettee.global.security.dto.oauth;
 
 /**
  * 소셜 미디어별 OAuth2 정보 변환해줄 추상 {@code DTO} 클래스

--- a/src/main/java/com/palettee/global/security/dto/token/FilterExceptionResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/token/FilterExceptionResponse.java
@@ -1,0 +1,7 @@
+package com.palettee.global.security.dto.token;
+
+import java.time.*;
+
+public record FilterExceptionResponse(int status, String reason, LocalDateTime timeStamp) {
+
+}

--- a/src/main/java/com/palettee/global/security/dto/token/TokenContainer.java
+++ b/src/main/java/com/palettee/global/security/dto/token/TokenContainer.java
@@ -1,0 +1,5 @@
+package com.palettee.global.security.dto.token;
+
+public record TokenContainer(String accessToken, String refreshToken, long expiresInSeconds) {
+
+}

--- a/src/main/java/com/palettee/global/security/dto/token/TokenIssueResponse.java
+++ b/src/main/java/com/palettee/global/security/dto/token/TokenIssueResponse.java
@@ -1,0 +1,5 @@
+package com.palettee.global.security.dto.token;
+
+public record TokenIssueResponse(String message, Long expiresIn) {
+
+}

--- a/src/main/java/com/palettee/global/security/jwt/controllers/TokenController.java
+++ b/src/main/java/com/palettee/global/security/jwt/controllers/TokenController.java
@@ -1,14 +1,9 @@
 package com.palettee.global.security.jwt.controllers;
 
-import com.palettee.global.redis.*;
 import com.palettee.global.security.dto.token.*;
-import com.palettee.global.security.jwt.exceptions.*;
-import com.palettee.global.security.jwt.utils.*;
-import com.palettee.user.domain.*;
-import com.palettee.user.repository.*;
+import com.palettee.global.security.jwt.services.*;
 import jakarta.servlet.http.*;
 import java.util.*;
-import java.util.function.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
 import org.springframework.web.bind.annotation.*;
@@ -20,13 +15,10 @@ import org.springframework.web.bind.annotation.*;
 @SuppressWarnings("LoggingSimilarMessage")
 public class TokenController {
 
-    private final JwtUtils jwtUtils;
-    private final UserRepository userRepo;
-    private final RedisService redisService;
+    private final TokenService tokenService;
 
     private static final String REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
     private static final String ACCESS_TOKEN_HEADER = "Authorization";
-
 
     /**
      * 요청의 {@code Query param} 으로 주어진 {@code 임시 토큰} 으로 {@code Access}, {@code Refresh} 토큰을 발급하는 API
@@ -36,34 +28,20 @@ public class TokenController {
     @GetMapping("/issue")
     public TokenIssueResponse issueToken(
             @RequestParam(value = "token", required = false) String temporaryToken,
-            HttpServletResponse resp
-    ) throws NoTokenExistsException, InvalidTokenException, ExpiredTokenException {
+            HttpServletResponse resp) {
 
-        // 토큰 검증 + 토큰 userEmail 로 유저 찾기
-        // 검증 실패 or 유저 못찾으면 메서드 속에서 throw 됨.
-        User user = validateTokenToUser(
-                temporaryToken,
-                jwtUtils::isTemporaryTokenExpired,
-                jwtUtils::isTemporaryTokenValid,
-                jwtUtils::getEmailFromTemporaryToken
-        );
+        TokenContainer result = tokenService.issueToken(temporaryToken);
 
-        log.info("Token were valid & available to find user via email");
-
-        // jwt 유효하고 유저도 찾을 수 있음 --> happy flow
-        String accessToken = jwtUtils.createAccessToken(user);
-        String refreshToken = jwtUtils.createRefreshToken(user);
+        String accessToken = result.accessToken();
+        String refreshToken = result.refreshToken();
+        long expireSec = result.expiresInSeconds();
 
         // 응답 헤더, 쿠키에 토큰 넣기
         this.plantTokens(accessToken, refreshToken, resp);
 
-        // redis 에 발급한 refresh 토큰 저장하기
-        redisService.storeRefreshToken(user, refreshToken, jwtUtils.getRefreshExpireMin());
+        log.info("Access & refresh tokens were issued");
 
-        return new TokenIssueResponse(
-                "토큰 발급이 완료되었습니다.",
-                60 * jwtUtils.getAccessExpireMin()
-        );
+        return new TokenIssueResponse("토큰 발급이 완료되었습니다.", expireSec);
     }
 
 
@@ -73,53 +51,23 @@ public class TokenController {
      * 이 때 {@code Redis} 에 저장된 {@code Refresh} 토큰이 없거나, 그것과 일치하는 {@code Refresh} 토큰이 제공되어야 발급
      */
     @PostMapping("/reissue")
-    public TokenIssueResponse reissueToken(HttpServletRequest req, HttpServletResponse resp)
-            throws NoTokenExistsException, InvalidTokenException, ExpiredTokenException {
+    public TokenIssueResponse reissueToken(HttpServletRequest req, HttpServletResponse resp) {
 
         // cookie 에서 refresh 토큰 꺼내오기
         String refreshToken = getRefreshTokenFromCookie(req);
 
-        // 토큰 검증 + 토큰 userEmail 로 유저 찾기
-        // 검증 실패 or 유저 못찾으면 메서드 속에서 throw 됨.
-        User user = validateTokenToUser(
-                refreshToken,
-                jwtUtils::isRefreshTokenExpired,
-                jwtUtils::isRefreshTokenValid,
-                jwtUtils::getEmailFromRefreshToken
-        );
+        TokenContainer result = tokenService.reissueToken(refreshToken);
 
-        log.info("Token were valid & available to find user via email");
-
-        // redis 에서도 꺼내 맞는지 확인해야 함.
-        String refreshTokenFromRedis = redisService.getRefreshToken(user).orElse(null);
-
-        // 주어진 토큰이 redis 의 것과 맞지 않음.
-        if (refreshTokenFromRedis != null && !refreshTokenFromRedis.equals(refreshToken)) {
-            log.warn("Refresh token were valid, but fail to verifying with redis-stored token.");
-            log.trace("Given refresh token : {}", refreshToken);
-            log.trace("Redis given refresh token : {}", refreshTokenFromRedis);
-
-            throw InvalidTokenException.EXCEPTION;
-        }
-
-        // redis 에 refresh 토큰이 없었거나, 있었는데 주어진 값과 동일하면
-        // --> happy flow
-
-        String accessToken = jwtUtils.createAccessToken(user);
-        String newRefreshToken = jwtUtils.createRefreshToken(user);
+        String accessToken = result.accessToken();
+        String newRefreshToken = result.refreshToken();
+        long expireSec = result.expiresInSeconds();
 
         // 응답 헤더, 쿠키에 토큰 넣기
         this.plantTokens(accessToken, newRefreshToken, resp);
 
-        // redis 에 새로운 refresh 토큰 저장하기
-        redisService.storeRefreshToken(user, newRefreshToken, jwtUtils.getRefreshExpireMin());
-
         log.info("Access & refresh tokens were reissued");
 
-        return new TokenIssueResponse(
-                "토큰 발급이 완료되었습니다.",
-                60 * jwtUtils.getAccessExpireMin()
-        );
+        return new TokenIssueResponse("토큰 발급이 완료되었습니다.", expireSec);
     }
 
 
@@ -135,29 +83,15 @@ public class TokenController {
             HttpServletResponse resp
     ) {
 
-        if (userEmail == null || userEmail.isEmpty()) {
-            log.error("userEmail 이 비어있습니다.");
-            throw new NullPointerException("userEmail 이 비어있습니다.");
-        }
+        TokenContainer result = tokenService.issueTokenOnlyWithEmail(userEmail);
 
-        User user = userRepo.findByEmail(userEmail).orElse(null);
+        String accessToken = result.accessToken();
+        String refreshToken = result.refreshToken();
+        long expireSec = result.expiresInSeconds();
 
-        if (user == null) {
-            log.error("주어진 email 로 유저를 찾을 수 없습니다.");
-            throw new NullPointerException("주어진 email 로 유저를 찾을 수 없습니다.");
-        }
+        this.plantTokens(accessToken, refreshToken, resp);
 
-        String accessToken = jwtUtils.createAccessToken(user);
-        String refreshToken = jwtUtils.createRefreshToken(user);
-
-        plantTokens(accessToken, refreshToken, resp);
-
-        redisService.storeRefreshToken(user, refreshToken, jwtUtils.getRefreshExpireMin());
-
-        return new TokenIssueResponse(
-                "토큰 발급이 완료되었습니다.",
-                60 * jwtUtils.getAccessExpireMin()
-        );
+        return new TokenIssueResponse("토큰 발급이 완료되었습니다.", expireSec);
     }
 
 
@@ -176,56 +110,16 @@ public class TokenController {
 
 
     /**
-     * 토큰 검증하고 payload 의 {@code userEmail} 로 유저 찾아서 반환하는 편의용 메서드
-     *
-     * @param token               jwt 토큰
-     * @param checkExpiration     토큰 유효기간이 만료됐는지 확인하는 function
-     * @param validateToken       토큰이 유효한지 확인하는 function
-     * @param getEmailFromPayload 토큰에서 {@code userEmail} payload 를 꺼내는 function
-     * @return 토큰으로 확실히 검증된 {@code User}
-     */
-    private User validateTokenToUser(String token,
-            Function<String, Boolean> checkExpiration,
-            Function<String, Boolean> validateToken,
-            Function<String, String> getEmailFromPayload)
-            throws NoTokenExistsException, InvalidTokenException, NoUserFoundViaTokenException {
-
-        // jwt 가 존재하지 않음.
-        if (token == null || token.isEmpty()) {
-            throw NoTokenExistsException.EXCEPTION;
-        }
-
-        // 유효기간이 지남
-        if (checkExpiration.apply(token)) {
-            throw ExpiredTokenException.EXCEPTION;
-        }
-
-        // jwt 가 유효하지 않음.
-        if (!validateToken.apply(token)) {
-            throw InvalidTokenException.EXCEPTION;
-        }
-
-        User user = userRepo.findByEmail(getEmailFromPayload.apply(token))
-                .orElse(null);
-
-        // jwt-userEmail 로 유저를 찾을 수 없음.
-        if (user == null) {
-            throw NoUserFoundViaTokenException.Exception;
-        }
-
-        return user;
-    }
-
-
-    /**
      * 토큰 생성하고 응답, 쿠키에 넣어주는 메서드
      */
     private void plantTokens(
             String accessToken, String refreshToken,
             HttpServletResponse resp
     ) {
-        Cookie refreshTokenCookie = createCookie(REFRESH_TOKEN_COOKIE_KEY,
-                refreshToken, jwtUtils.getRefreshExpireMin());
+
+        Cookie refreshTokenCookie = tokenService.createRefreshTokenCookie(
+                REFRESH_TOKEN_COOKIE_KEY, refreshToken
+        );
 
         // 쿠키에 refresh 토큰 넣기
         resp.addCookie(refreshTokenCookie);
@@ -234,17 +128,5 @@ public class TokenController {
         // 응답 헤더에 access 토큰 넣기
         resp.setHeader(ACCESS_TOKEN_HEADER, accessToken);
         log.debug("Set access token on response header : {}", accessToken);
-    }
-
-
-    @SuppressWarnings("SameParameterValue")
-    private Cookie createCookie(String key, String value, long expireMin) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60 * 1_000 * (int) expireMin);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-
-        return cookie;
     }
 }

--- a/src/main/java/com/palettee/global/security/jwt/controllers/TokenController.java
+++ b/src/main/java/com/palettee/global/security/jwt/controllers/TokenController.java
@@ -1,0 +1,250 @@
+package com.palettee.global.security.jwt.controllers;
+
+import com.palettee.global.redis.*;
+import com.palettee.global.security.dto.token.*;
+import com.palettee.global.security.jwt.exceptions.*;
+import com.palettee.global.security.jwt.utils.*;
+import com.palettee.user.domain.*;
+import com.palettee.user.repository.*;
+import jakarta.servlet.http.*;
+import java.util.*;
+import java.util.function.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/token")
+@RequiredArgsConstructor
+@SuppressWarnings("LoggingSimilarMessage")
+public class TokenController {
+
+    private final JwtUtils jwtUtils;
+    private final UserRepository userRepo;
+    private final RedisService redisService;
+
+    private static final String REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
+    private static final String ACCESS_TOKEN_HEADER = "Authorization";
+
+
+    /**
+     * 요청의 {@code Query param} 으로 주어진 {@code 임시 토큰} 으로 {@code Access}, {@code Refresh} 토큰을 발급하는 API
+     *
+     * @param temporaryToken 유효기간이 짧은 임시 토큰
+     */
+    @GetMapping("/issue")
+    public TokenIssueResponse issueToken(
+            @RequestParam(value = "token", required = false) String temporaryToken,
+            HttpServletResponse resp
+    ) throws NoTokenExistsException, InvalidTokenException, ExpiredTokenException {
+
+        // 토큰 검증 + 토큰 userEmail 로 유저 찾기
+        // 검증 실패 or 유저 못찾으면 메서드 속에서 throw 됨.
+        User user = validateTokenToUser(
+                temporaryToken,
+                jwtUtils::isTemporaryTokenExpired,
+                jwtUtils::isTemporaryTokenValid,
+                jwtUtils::getEmailFromTemporaryToken
+        );
+
+        log.info("Token were valid & available to find user via email");
+
+        // jwt 유효하고 유저도 찾을 수 있음 --> happy flow
+        String accessToken = jwtUtils.createAccessToken(user);
+        String refreshToken = jwtUtils.createRefreshToken(user);
+
+        // 응답 헤더, 쿠키에 토큰 넣기
+        this.plantTokens(accessToken, refreshToken, resp);
+
+        // redis 에 발급한 refresh 토큰 저장하기
+        redisService.storeRefreshToken(user, refreshToken, jwtUtils.getRefreshExpireMin());
+
+        return new TokenIssueResponse(
+                "토큰 발급이 완료되었습니다.",
+                60 * jwtUtils.getAccessExpireMin()
+        );
+    }
+
+
+    /**
+     * 쿠키의 {@code Refresh} 토큰으로 {@code Access}, {@code Refresh} 토큰 발급하는 API
+     * <p>
+     * 이 때 {@code Redis} 에 저장된 {@code Refresh} 토큰이 없거나, 그것과 일치하는 {@code Refresh} 토큰이 제공되어야 발급
+     */
+    @PostMapping("/reissue")
+    public TokenIssueResponse reissueToken(HttpServletRequest req, HttpServletResponse resp)
+            throws NoTokenExistsException, InvalidTokenException, ExpiredTokenException {
+
+        // cookie 에서 refresh 토큰 꺼내오기
+        String refreshToken = getRefreshTokenFromCookie(req);
+
+        // 토큰 검증 + 토큰 userEmail 로 유저 찾기
+        // 검증 실패 or 유저 못찾으면 메서드 속에서 throw 됨.
+        User user = validateTokenToUser(
+                refreshToken,
+                jwtUtils::isRefreshTokenExpired,
+                jwtUtils::isRefreshTokenValid,
+                jwtUtils::getEmailFromRefreshToken
+        );
+
+        log.info("Token were valid & available to find user via email");
+
+        // redis 에서도 꺼내 맞는지 확인해야 함.
+        String refreshTokenFromRedis = redisService.getRefreshToken(user).orElse(null);
+
+        // 주어진 토큰이 redis 의 것과 맞지 않음.
+        if (refreshTokenFromRedis != null && !refreshTokenFromRedis.equals(refreshToken)) {
+            log.warn("Refresh token were valid, but fail to verifying with redis-stored token.");
+            log.trace("Given refresh token : {}", refreshToken);
+            log.trace("Redis given refresh token : {}", refreshTokenFromRedis);
+
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        // redis 에 refresh 토큰이 없었거나, 있었는데 주어진 값과 동일하면
+        // --> happy flow
+
+        String accessToken = jwtUtils.createAccessToken(user);
+        String newRefreshToken = jwtUtils.createRefreshToken(user);
+
+        // 응답 헤더, 쿠키에 토큰 넣기
+        this.plantTokens(accessToken, newRefreshToken, resp);
+
+        // redis 에 새로운 refresh 토큰 저장하기
+        redisService.storeRefreshToken(user, newRefreshToken, jwtUtils.getRefreshExpireMin());
+
+        log.info("Access & refresh tokens were reissued");
+
+        return new TokenIssueResponse(
+                "토큰 발급이 완료되었습니다.",
+                60 * jwtUtils.getAccessExpireMin()
+        );
+    }
+
+
+    /**
+     * 개발 중 원활한 테스트를 위해 {@code userEmail} 로 토큰 발급해주는 API
+     *
+     * @param userEmail DB 에 존재하는 어느 유저의 email
+     */
+    // TODO : 개발 완료되면 삭제해야 함.
+    @PostMapping("/test-issue")
+    public TokenIssueResponse testIssueToken(
+            @RequestParam(value = "userEmail", required = false) String userEmail,
+            HttpServletResponse resp
+    ) {
+
+        if (userEmail == null || userEmail.isEmpty()) {
+            log.error("userEmail 이 비어있습니다.");
+            throw new NullPointerException("userEmail 이 비어있습니다.");
+        }
+
+        User user = userRepo.findByEmail(userEmail).orElse(null);
+
+        if (user == null) {
+            log.error("주어진 email 로 유저를 찾을 수 없습니다.");
+            throw new NullPointerException("주어진 email 로 유저를 찾을 수 없습니다.");
+        }
+
+        String accessToken = jwtUtils.createAccessToken(user);
+        String refreshToken = jwtUtils.createRefreshToken(user);
+
+        plantTokens(accessToken, refreshToken, resp);
+
+        redisService.storeRefreshToken(user, refreshToken, jwtUtils.getRefreshExpireMin());
+
+        return new TokenIssueResponse(
+                "토큰 발급이 완료되었습니다.",
+                60 * jwtUtils.getAccessExpireMin()
+        );
+    }
+
+
+    /**
+     * 쿠키에서 {@code Refresh} 토큰 꺼내오기
+     */
+    private String getRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        return Arrays.stream(cookies).parallel()
+                .filter(cookie -> cookie.getName().equals(REFRESH_TOKEN_COOKIE_KEY))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+
+
+    /**
+     * 토큰 검증하고 payload 의 {@code userEmail} 로 유저 찾아서 반환하는 편의용 메서드
+     *
+     * @param token               jwt 토큰
+     * @param checkExpiration     토큰 유효기간이 만료됐는지 확인하는 function
+     * @param validateToken       토큰이 유효한지 확인하는 function
+     * @param getEmailFromPayload 토큰에서 {@code userEmail} payload 를 꺼내는 function
+     * @return 토큰으로 확실히 검증된 {@code User}
+     */
+    private User validateTokenToUser(String token,
+            Function<String, Boolean> checkExpiration,
+            Function<String, Boolean> validateToken,
+            Function<String, String> getEmailFromPayload)
+            throws NoTokenExistsException, InvalidTokenException, NoUserFoundViaTokenException {
+
+        // jwt 가 존재하지 않음.
+        if (token == null || token.isEmpty()) {
+            throw NoTokenExistsException.EXCEPTION;
+        }
+
+        // 유효기간이 지남
+        if (checkExpiration.apply(token)) {
+            throw ExpiredTokenException.EXCEPTION;
+        }
+
+        // jwt 가 유효하지 않음.
+        if (!validateToken.apply(token)) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        User user = userRepo.findByEmail(getEmailFromPayload.apply(token))
+                .orElse(null);
+
+        // jwt-userEmail 로 유저를 찾을 수 없음.
+        if (user == null) {
+            throw NoUserFoundViaTokenException.Exception;
+        }
+
+        return user;
+    }
+
+
+    /**
+     * 토큰 생성하고 응답, 쿠키에 넣어주는 메서드
+     */
+    private void plantTokens(
+            String accessToken, String refreshToken,
+            HttpServletResponse resp
+    ) {
+        Cookie refreshTokenCookie = createCookie(REFRESH_TOKEN_COOKIE_KEY,
+                refreshToken, jwtUtils.getRefreshExpireMin());
+
+        // 쿠키에 refresh 토큰 넣기
+        resp.addCookie(refreshTokenCookie);
+        log.debug("Set refresh token on cookie : {}", refreshTokenCookie);
+
+        // 응답 헤더에 access 토큰 넣기
+        resp.setHeader(ACCESS_TOKEN_HEADER, accessToken);
+        log.debug("Set access token on response header : {}", accessToken);
+    }
+
+
+    @SuppressWarnings("SameParameterValue")
+    private Cookie createCookie(String key, String value, long expireMin) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60 * 1_000 * (int) expireMin);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/exceptions/ExpiredTokenException.java
+++ b/src/main/java/com/palettee/global/security/jwt/exceptions/ExpiredTokenException.java
@@ -1,0 +1,12 @@
+package com.palettee.global.security.jwt.exceptions;
+
+import com.palettee.global.exception.*;
+
+public class ExpiredTokenException extends PaletteException {
+
+    public static final PaletteException EXCEPTION = new ExpiredTokenException();
+
+    private ExpiredTokenException() {
+        super(ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/exceptions/InvalidTokenException.java
+++ b/src/main/java/com/palettee/global/security/jwt/exceptions/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package com.palettee.global.security.jwt.exceptions;
+
+import com.palettee.global.exception.*;
+
+public class InvalidTokenException extends PaletteException {
+
+    public static final PaletteException EXCEPTION = new InvalidTokenException();
+
+    private InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/exceptions/NoTokenExistsException.java
+++ b/src/main/java/com/palettee/global/security/jwt/exceptions/NoTokenExistsException.java
@@ -1,0 +1,12 @@
+package com.palettee.global.security.jwt.exceptions;
+
+import com.palettee.global.exception.*;
+
+public class NoTokenExistsException extends PaletteException {
+
+    public static final PaletteException EXCEPTION = new NoTokenExistsException();
+
+    private NoTokenExistsException() {
+        super(ErrorCode.NO_TOKEN_EXISTS);
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/exceptions/NoUserFoundViaTokenException.java
+++ b/src/main/java/com/palettee/global/security/jwt/exceptions/NoUserFoundViaTokenException.java
@@ -1,0 +1,12 @@
+package com.palettee.global.security.jwt.exceptions;
+
+import com.palettee.global.exception.*;
+
+public class NoUserFoundViaTokenException extends PaletteException {
+
+    public static final PaletteException Exception = new NoUserFoundViaTokenException();
+
+    private NoUserFoundViaTokenException() {
+        super(ErrorCode.NO_USER_FOUND_VIA_TOKEN);
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/exceptions/RoleMismatchException.java
+++ b/src/main/java/com/palettee/global/security/jwt/exceptions/RoleMismatchException.java
@@ -1,0 +1,12 @@
+package com.palettee.global.security.jwt.exceptions;
+
+import com.palettee.global.exception.*;
+
+public class RoleMismatchException extends PaletteException {
+
+    public static final PaletteException EXCEPTION = new RoleMismatchException();
+
+    private RoleMismatchException() {
+        super(ErrorCode.ROLE_MISMATCH);
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/filters/JwtExceptionHandlingFilter.java
+++ b/src/main/java/com/palettee/global/security/jwt/filters/JwtExceptionHandlingFilter.java
@@ -1,0 +1,58 @@
+package com.palettee.global.security.jwt.filters;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.*;
+import com.palettee.global.exception.*;
+import com.palettee.global.security.dto.token.*;
+import com.palettee.global.security.jwt.exceptions.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import java.io.*;
+import java.time.*;
+import lombok.extern.slf4j.*;
+import org.springframework.http.*;
+import org.springframework.web.filter.*;
+
+/**
+ * JwtFilter 에서 발생한 exception 들을 잡아 응답하기 위한 filter
+ */
+@Slf4j
+public class JwtExceptionHandlingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredTokenException | InvalidTokenException | NoTokenExistsException
+                 | NoUserFoundViaTokenException | RoleMismatchException e) {
+
+            log.warn("Jwt exception occurred at {}", request.getRequestURI());
+
+            ErrorCode err = e.getErrorCode();
+            responseErr(err.getStatus(), err.getReason(), e, response);
+        } catch (Exception e) {
+            log.error("Unexpected exception occurred at {}", request.getRequestURI());
+
+            responseErr(500, e.getMessage(), e, response);
+        }
+    }
+
+    private void responseErr(int status, String reason, Exception e, HttpServletResponse resp)
+            throws IOException {
+        resp.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        resp.setCharacterEncoding("UTF-8");
+        resp.setStatus(status);
+
+        FilterExceptionResponse response = new FilterExceptionResponse(
+                status, reason, LocalDateTime.now()
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        resp.getWriter().write(objectMapper.writeValueAsString(response));
+
+        log.error("JwtExceptionHandlingFilter handled exception: {}", e.getClass().getSimpleName());
+        log.error("Exception message: {}", e.getMessage());
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/filters/JwtFilter.java
+++ b/src/main/java/com/palettee/global/security/jwt/filters/JwtFilter.java
@@ -1,0 +1,177 @@
+package com.palettee.global.security.jwt.filters;
+
+import com.palettee.global.security.jwt.exceptions.*;
+import com.palettee.global.security.jwt.utils.*;
+import com.palettee.global.security.oauth.*;
+import com.palettee.user.domain.*;
+import com.palettee.user.repository.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import java.io.*;
+import java.util.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.http.*;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.*;
+import org.springframework.security.core.context.*;
+import org.springframework.web.filter.*;
+
+/**
+ * 요청 헤더의 Access 토큰으로 SecurityContext 에 유저 정보 넣어주기 위한 jwt filter
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    private final UserRepository userRepo;
+
+    private final Map<String, List<HttpMethod>> byPassableUris;
+    private final Map<String, List<HttpMethod>> conditionalAuthUris;
+
+    private static final String ACCESS_TOKEN_HEADER = "Authorization";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 현재 요청이 권한 필요없는 요청이면 jwt 동작 안하기
+        if (isByPassable(request)) {
+            logBypass(request);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        log.info("Request is not a candidate for bypass.");
+
+        // 만약 jwt 파싱시 에러 터져도 그냥 넘어가도 되는지 확인
+        boolean conditionalAuthRequired = conditionalAuthRequired(request);
+
+        // request header 에서 jwt 꺼내기
+        String token = request.getHeader(ACCESS_TOKEN_HEADER);
+
+        log.info("Token in request header : {}", token);
+
+        // jwt 유효?
+        if (jwtUtils.isAccessTokenValid(token)) {
+            log.info("Access token in request header is valid.");
+
+            String userEmail = jwtUtils.getEmailFromAccessToken(token);
+            User user = userRepo.findByEmail(userEmail).orElse(null);
+
+            // jwt-userEmail 로 유저 찾음?
+            if (user == null) {
+                log.warn("No user found with email: {}", userEmail);
+
+                if (!conditionalAuthRequired) {
+                    log.error("Failed to authenticate user: {}", userEmail);
+                    throw NoUserFoundViaTokenException.Exception;
+                }
+
+                logConditionalBypass(NoUserFoundViaTokenException.Exception.getMessage());
+            }
+
+            // user 찾았으니까
+            // Security Context 에 유저 정보 넣어주기
+            else {
+                CustomOAuth2User authUser = new CustomOAuth2User(user);
+                Authentication authToken = new UsernamePasswordAuthenticationToken(authUser, null,
+                        authUser.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                log.info("User info were recorded to security context.");
+            }
+        }
+
+        // jwt 유효하진 않은데 에러는 안 터트려도 됨?
+        else if (conditionalAuthRequired) {
+            logConditionalBypass(InvalidTokenException.EXCEPTION.getMessage());
+        }
+
+        // jwt 필요한데 유효하지 않았음 --> 에러처리
+        // 토큰 없던거 아님?
+        else if (token == null || token.isEmpty()) {
+            log.error("No token exists.");
+            throw NoTokenExistsException.EXCEPTION;
+        }
+
+        // 토큰 만료된거 아님?
+        else if (jwtUtils.isAccessTokenExpired(token)) {
+            log.error("Token were expired.");
+            throw ExpiredTokenException.EXCEPTION;
+        }
+
+        // 모르겠고 invalid
+        else {
+            log.error("Token is invalid");
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+
+    /**
+     * 현 요청을 filter 로직 수행 안해도 되는지 확인
+     */
+    private boolean isByPassable(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String httpMethod = request.getMethod().toUpperCase();
+
+        log.info("Request uri: {} - {}", httpMethod, requestUri);
+
+        return hasMatch(byPassableUris, requestUri, httpMethod);
+    }
+
+    /**
+     * filter 를 거치긴 하지만 에러를 터트리지 않아도 되는지 확인
+     *
+     * @return {@code true} 면 에러 X
+     */
+    private boolean conditionalAuthRequired(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String httpMethod = request.getMethod().toUpperCase();
+
+        return hasMatch(conditionalAuthUris, requestUri, httpMethod);
+    }
+
+
+    /**
+     * 현재 요청이 정의된 {@code uriRegexMap} 에 포함되는지 알려주는 메서드
+     *
+     * @param uriRegexMap 확인할 {@code URI} 의 정규 표현식 + {@link  HttpMethod}
+     * @param uri         검사할 요청의 {@code URI}
+     * @param httpMethod  검사할 요청의 {@code HttpMethod} (대문자)
+     * @return 현재 요청이 {@code uriRegexMap} 에 속해 있다면 {@code true}
+     */
+    private boolean hasMatch(Map<String, List<HttpMethod>> uriRegexMap, String uri,
+            String httpMethod) {
+        // key 값 중 matches 인 url 뱉기
+        String matchingUrl = uriRegexMap.keySet().parallelStream()
+                .filter(uri::matches)
+                .findFirst().orElse(null);
+
+        // match 하는 url 가 존재하고 httpMethod 도 동일하면 true
+        return matchingUrl != null &&
+                uriRegexMap.get(matchingUrl).stream()
+                        .map(HttpMethod::name)
+                        .map(String::toUpperCase)
+                        .anyMatch(httpMethod::equals);
+    }
+
+    private static void logBypass(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String httpMethod = request.getMethod().toUpperCase();
+
+        log.info("Request matches to bypass list.");
+        log.info("Bypassing JwtFilter on request : {} - {}", httpMethod, requestUri);
+    }
+
+    private static void logConditionalBypass(String msg) {
+        log.info("Bypassing exception due to conditional authentication : {}", msg);
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/palettee/global/security/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,51 @@
+package com.palettee.global.security.jwt.handler;
+
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.datatype.jsr310.*;
+import com.palettee.global.exception.*;
+import com.palettee.global.security.dto.token.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import java.io.*;
+import java.time.*;
+import lombok.extern.slf4j.*;
+import org.springframework.http.*;
+import org.springframework.security.access.*;
+import org.springframework.security.web.access.*;
+import org.springframework.stereotype.*;
+
+/**
+ * Jwt 로 유저 확인은 가능하나 더 높은 권한이 필요할 때 행동하는 handler
+ */
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        log.error("Higher authorize required in request: {} - {}", request.getMethod(),
+                request.getRequestURI());
+
+        ErrorCode err = ErrorCode.ROLE_MISMATCH;
+        int status = err.getStatus();
+        String reason = err.getReason();
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(status);
+
+        FilterExceptionResponse body = new FilterExceptionResponse(
+                status, reason, LocalDateTime.now()
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+
+        log.error("JwtAccessDeniedHandler handled exception: {}",
+                accessDeniedException.getClass().getSimpleName());
+        log.error("Exception message: {}", accessDeniedException.getMessage());
+    }
+}

--- a/src/main/java/com/palettee/global/security/jwt/services/TokenService.java
+++ b/src/main/java/com/palettee/global/security/jwt/services/TokenService.java
@@ -1,0 +1,183 @@
+package com.palettee.global.security.jwt.services;
+
+import com.palettee.global.redis.*;
+import com.palettee.global.security.dto.token.*;
+import com.palettee.global.security.jwt.exceptions.*;
+import com.palettee.global.security.jwt.utils.*;
+import com.palettee.user.domain.*;
+import com.palettee.user.repository.*;
+import jakarta.servlet.http.*;
+import java.util.function.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtUtils jwtUtils;
+    private final UserRepository userRepo;
+    private final RedisService redisService;
+
+    /**
+     * 임시 토큰으로 필수 토큰들을 발급
+     *
+     * @param temporaryToken 임시 토큰
+     * @return {@code Access}, {@code Refresh} 토큰이 담긴 {@code DTO}
+     * @throws NoTokenExistsException       토큰이 {@code null} 이거나 비어있을 시
+     * @throws ExpiredTokenException        토큰 유효기간이 지났을 시
+     * @throws InvalidTokenException        토큰이 유효하지 않을 시
+     * @throws NoUserFoundViaTokenException 토큰은 유효하나 payload 의 {@code userEmail} 과 매칭되는 유저가 없을 시
+     */
+    public TokenContainer issueToken(String temporaryToken)
+            throws NoTokenExistsException, ExpiredTokenException,
+            InvalidTokenException, NoUserFoundViaTokenException {
+
+        User user = validateTokenAndLinkToUser(
+                temporaryToken,
+                jwtUtils::isTemporaryTokenExpired,
+                jwtUtils::isTemporaryTokenValid,
+                jwtUtils::getEmailFromTemporaryToken
+        );
+
+        String accessToken = jwtUtils.createAccessToken(user);
+        String refreshToken = jwtUtils.createRefreshToken(user);
+
+        // 새로 발급된 refresh 를 redis 에 저장
+        redisService.storeRefreshToken(user, refreshToken, jwtUtils.getRefreshExpireMin());
+
+        return new TokenContainer(accessToken, refreshToken,
+                60 * jwtUtils.getAccessExpireMin());
+    }
+
+
+    /**
+     * {@code Refresh} 토큰으로 필수 토큰들을 발급
+     *
+     * @return {@code Access}, {@code Refresh} 토큰이 담긴 {@code DTO}
+     * @throws NoTokenExistsException       토큰이 {@code null} 이거나 비어있을 시
+     * @throws ExpiredTokenException        토큰 유효기간이 지났을 시
+     * @throws InvalidTokenException        토큰이 유효하지 않을 시
+     * @throws NoUserFoundViaTokenException 토큰은 유효하나 payload 의 {@code userEmail} 과 매칭되는 유저가 없을 시
+     */
+    public TokenContainer reissueToken(String refreshToken)
+            throws NoTokenExistsException, ExpiredTokenException,
+            InvalidTokenException, NoUserFoundViaTokenException {
+
+        User user = validateTokenAndLinkToUser(
+                refreshToken,
+                jwtUtils::isRefreshTokenExpired,
+                jwtUtils::isRefreshTokenValid,
+                jwtUtils::getEmailFromRefreshToken
+        );
+
+        String redisRefreshToken = redisService.getRefreshToken(user).orElse(null);
+
+        if (redisRefreshToken != null && !redisRefreshToken.equals(refreshToken)) {
+            log.warn("Refresh token were valid, but fail to verifying with redis-stored token.");
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        String accessToken = jwtUtils.createAccessToken(user);
+        String newRefreshToken = jwtUtils.createRefreshToken(user);
+
+        // 새로 발급된 refresh 를 redis 에 저장
+        redisService.storeRefreshToken(user, newRefreshToken, jwtUtils.getRefreshExpireMin());
+
+        return new TokenContainer(accessToken, newRefreshToken,
+                60 * jwtUtils.getAccessExpireMin());
+    }
+
+
+    /* !!! ------------------------------- !!! */
+    // TODO : 개발 완료되면 삭제해야 함.
+    public TokenContainer issueTokenOnlyWithEmail(String userEmail) {
+
+        User user;
+
+        if (userEmail == null || userEmail.isEmpty() ||
+                (user = userRepo.findByEmail(userEmail).orElse(null)) == null) {
+            log.error("주어진 이메일로 유저를 찾을 수 없습니다.");
+            throw new IllegalArgumentException("주어진 이메일로 유저를 찾을 수 없습니다.");
+        }
+
+        String accessToken = jwtUtils.createAccessToken(user);
+        String refreshToken = jwtUtils.createRefreshToken(user);
+
+        redisService.storeRefreshToken(user, refreshToken, jwtUtils.getRefreshExpireMin());
+
+        return new TokenContainer(accessToken, refreshToken,
+                60 * jwtUtils.getRefreshExpireMin());
+    }
+    /* !!! ------------------------------- !!! */
+
+
+    /**
+     * 토큰 검증을 진행하고 연관된 유저를 반환하는 메서드
+     *
+     * @param checkTokenExpiration 토큰 유효기간을 확인하는 function. 만료되면 {@code true} 를 뱉어야 함.
+     * @param checkTokenValidation 토큰 유효성을 확인하는 function. 유효하면 {@code true} 를 뱉어야 함.
+     * @param getEmailFromPayload  토큰 payload 에서 {@code userEmail} 값을 꺼내는 function.
+     * @return 토큰과 연관된 {@code User}
+     * @throws NoTokenExistsException       토큰이 {@code null} 이거나 비어있을 시
+     * @throws ExpiredTokenException        토큰 유효기간이 지났을 시
+     * @throws InvalidTokenException        토큰이 유효하지 않을 시
+     * @throws NoUserFoundViaTokenException 토큰은 유효하나 payload 의 {@code userEmail} 과 매칭되는 유저가 없을 시
+     */
+    private User validateTokenAndLinkToUser(
+            String token,
+            Function<String, Boolean> checkTokenExpiration,
+            Function<String, Boolean> checkTokenValidation,
+            Function<String, String> getEmailFromPayload
+    ) throws NoTokenExistsException, ExpiredTokenException,
+            InvalidTokenException, NoUserFoundViaTokenException {
+
+        // jwt 가 존재하지 않음
+        if (token == null || token.isEmpty()) {
+            throw NoTokenExistsException.EXCEPTION;
+        }
+
+        // 유효기간이 지남
+        if (checkTokenExpiration.apply(token)) {
+            throw ExpiredTokenException.EXCEPTION;
+        }
+
+        // jwt 가 유효하지 않음
+        if (!checkTokenValidation.apply(token)) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        User user = userRepo.findByEmail(
+                getEmailFromPayload.apply(token)
+        ).orElse(null);
+        // jwt 는 유효하나 연관된 유저를 찾을 수 없음
+        if (user == null) {
+            throw NoUserFoundViaTokenException.Exception;
+        }
+
+        log.info("Token were valid & available to find user via email");
+
+        return user;
+    }
+
+
+    /**
+     * {@code Refresh} 토큰이 담긴 쿠키를 생성
+     *
+     * @param key 쿠키 {@code key}
+     */
+    public Cookie createRefreshTokenCookie(String key, String token) {
+        Cookie cookie = new Cookie(key, token);
+
+        // 쿠키 시간은 ms
+        cookie.setMaxAge(60 * 1_000 * (int) jwtUtils.getRefreshExpireMin());
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+}

--- a/src/main/java/com/palettee/global/security/jwt/utils/CustomJwtUtil.java
+++ b/src/main/java/com/palettee/global/security/jwt/utils/CustomJwtUtil.java
@@ -23,7 +23,8 @@ final class CustomJwtUtil {
     }
 
     private static void logDebug(String s, Exception e) {
-        log.debug(s, e);
+        log.debug(s, e.getMessage());
+        log.trace("Caused by: ", e);
     }
 
     public boolean isValid(String token) {
@@ -32,10 +33,10 @@ final class CustomJwtUtil {
                     .parseSignedClaims(token)
                     .getPayload();
 
-            String email = claims.get("email", String.class);
+            String userEmail = claims.get("userEmail", String.class);
             Date expiration = claims.getExpiration();
 
-            if (email == null || email.isEmpty()) {
+            if (userEmail == null || userEmail.isEmpty()) {
                 logDebug("Cannot find userEmail claims in jwt {}", new NullPointerException());
                 return false;
             }

--- a/src/main/java/com/palettee/global/security/jwt/utils/CustomJwtUtil.java
+++ b/src/main/java/com/palettee/global/security/jwt/utils/CustomJwtUtil.java
@@ -1,4 +1,4 @@
-package com.palettee.global.security.jwt;
+package com.palettee.global.security.jwt.utils;
 
 import com.palettee.user.domain.*;
 import io.jsonwebtoken.*;

--- a/src/main/java/com/palettee/global/security/jwt/utils/JwtUtils.java
+++ b/src/main/java/com/palettee/global/security/jwt/utils/JwtUtils.java
@@ -1,8 +1,9 @@
 package com.palettee.global.security.jwt.utils;
 
 import com.palettee.user.domain.*;
+import lombok.*;
 import lombok.extern.slf4j.*;
-import org.springframework.beans.factory.annotation.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.*;
 
 /**
@@ -18,9 +19,9 @@ public class JwtUtils {
     private final CustomJwtUtil accessJwtUtil;
     private final CustomJwtUtil refreshJwtUtil;
 
-    private final long tempoExpireMin;
-    private final long accessExpireMin;
-    private final long refreshExpireMin;
+    private final @Getter long tempoExpireMin;
+    private final @Getter long accessExpireMin;
+    private final @Getter long refreshExpireMin;
 
     public JwtUtils(
             @Value("${jwt.temporary.secret}") String tempoSecret,

--- a/src/main/java/com/palettee/global/security/jwt/utils/JwtUtils.java
+++ b/src/main/java/com/palettee/global/security/jwt/utils/JwtUtils.java
@@ -1,4 +1,4 @@
-package com.palettee.global.security.jwt;
+package com.palettee.global.security.jwt.utils;
 
 import com.palettee.user.domain.*;
 import lombok.extern.slf4j.*;

--- a/src/main/java/com/palettee/global/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/palettee/global/security/oauth/CustomOAuth2User.java
@@ -27,7 +27,7 @@ public class CustomOAuth2User implements OAuth2User {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(
                 new SimpleGrantedAuthority(
-                        user.getUserRole().toString())
+                        "ROLE_" + user.getUserRole().toString())
         );
 
         return authorities;
@@ -35,10 +35,12 @@ public class CustomOAuth2User implements OAuth2User {
 
     /**
      * {@link OAuth2LoginSuccessHandler} 에서 로그인 성공 시, 이 메서드로 로그인된 정보 가져올 수 있음.
+     *
+     * @return {@link User#getEmail()}
      */
     @Override
     public String getName() {
-        return user.getName();
+        return user.getEmail();
     }
 
     /**

--- a/src/main/java/com/palettee/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/palettee/global/security/oauth/CustomOAuth2UserService.java
@@ -1,6 +1,6 @@
 package com.palettee.global.security.oauth;
 
-import com.palettee.global.security.dto.*;
+import com.palettee.global.security.dto.oauth.*;
 import com.palettee.user.domain.*;
 import com.palettee.user.repository.*;
 import java.util.*;

--- a/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -1,6 +1,6 @@
 package com.palettee.global.security.oauth.handler;
 
-import com.palettee.global.security.jwt.*;
+import com.palettee.global.security.jwt.utils.*;
 import com.palettee.global.security.oauth.*;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+
+# Swagger -> localhost:8080/api-test
+springdoc:
+  swagger-ui:
+    path: /api-test
+    groups-order: desc
+    tags-sorter: alpha
+    operations-sorter: method

--- a/src/test/java/com/palettee/global/security/jwt/controllers/TokenControllerTest.java
+++ b/src/test/java/com/palettee/global/security/jwt/controllers/TokenControllerTest.java
@@ -47,15 +47,17 @@ class TokenControllerTest {
 
     @BeforeEach
     void setUp() {
-        try {
-            testUser = userRepo.save(
-                    User.builder()
-                            .email("test@test.com")
-                            .build()
-            );
-        } catch (Exception e) {
-            testUser = userRepo.findByEmail(testUser.getEmail()).orElseThrow();
-        }
+        testUser = userRepo.save(
+                User.builder()
+                        .email("test@test.com")
+                        .build()
+        );
+    }
+
+    @AfterEach
+    void remove() {
+        redisService.deleteRefreshToken(testUser);
+        userRepo.delete(testUser);
     }
 
     @Test

--- a/src/test/java/com/palettee/global/security/jwt/controllers/TokenControllerTest.java
+++ b/src/test/java/com/palettee/global/security/jwt/controllers/TokenControllerTest.java
@@ -1,0 +1,161 @@
+package com.palettee.global.security.jwt.controllers;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.palettee.global.exception.*;
+import com.palettee.global.redis.*;
+import com.palettee.global.security.jwt.exceptions.*;
+import com.palettee.global.security.jwt.utils.*;
+import com.palettee.user.domain.*;
+import com.palettee.user.repository.*;
+import jakarta.servlet.http.*;
+import jakarta.transaction.*;
+import java.util.function.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.test.autoconfigure.web.servlet.*;
+import org.springframework.boot.test.context.*;
+import org.springframework.security.test.context.support.*;
+import org.springframework.test.context.junit.jupiter.*;
+import org.springframework.test.web.servlet.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@Transactional
+class TokenControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    JwtUtils jwtUtils;
+
+    @Autowired
+    RedisService redisService;
+
+    @Autowired
+    UserRepository userRepo;
+
+    private static User testUser;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        try {
+            testUser = userRepo.save(
+                    User.builder()
+                            .email("test@test.com")
+                            .build()
+            );
+        } catch (Exception e) {
+            testUser = userRepo.findByEmail(testUser.getEmail()).orElseThrow();
+        }
+    }
+
+    @Test
+    @DisplayName("임시 토큰으로 필수 토큰을 발급")
+    @WithAnonymousUser
+    void issueToken() throws Exception {
+
+        String temporaryToken = jwtUtils.createTemporaryToken(testUser);
+
+        // status ok 하고 토큰 응답 잘 됐는지 확인
+        MvcResult mvcResult = mvc.perform(get("/token/issue?token=" + temporaryToken))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Authorization"))
+                .andExpect(cookie().exists("refresh_token"))
+                .andReturn();
+
+        // 토큰 제대로 있는지 확인
+        this.checkTokens(mvcResult);
+
+        // 에러 발생 확인
+        this.checkException(
+                "/token/issue?token=", (url, token) -> get(url + token),
+                jwtUtils::createTemporaryToken
+        );
+    }
+
+    @Test
+    @DisplayName("쿠키의 Refresh 토큰으로 재발급")
+    @WithAnonymousUser
+    void reissueToken() throws Exception {
+
+        String refreshToken = jwtUtils.createRefreshToken(testUser);
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+        redisService.storeRefreshToken(testUser, refreshToken, 10L);
+
+        MvcResult mvcResult = mockMvc.perform(post("/token/reissue").cookie(cookie))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Authorization"))
+                .andExpect(cookie().exists("refresh_token"))
+                .andReturn();
+
+        // 토큰 제대로 있는지 확인
+        this.checkTokens(mvcResult);
+
+        // 새로운 refresh 토큰이 redis 에 저장됐는지 확인
+        assertThat(redisService.getRefreshToken(testUser).orElseThrow())
+                .isNotEqualTo(refreshToken);
+
+        // 에러 발생 확인
+        this.checkException(
+                "/token/reissue",
+                (url, token) -> post(url).cookie(new Cookie("refresh_token", token)),
+                jwtUtils::createRefreshToken
+        );
+    }
+
+    private void checkTokens(MvcResult mvcResult) {
+
+        // 응답 헤더의 access 토큰 존재하는지 확인
+        assertThat(mvcResult.getResponse().getHeader("Authorization"))
+                .isNotEmpty();
+
+        // 응답 쿠키에서 refresh 토큰 꺼냄
+        Cookie cookie = mvcResult.getResponse().getCookie("refresh_token");
+        assertThat(cookie).isNotNull();
+
+        // redis 에 저장된 값과 동일한지 확인
+        String refreshToken = cookie.getValue();
+        assertThat(redisService.getRefreshToken(testUser))
+                .isNotEmpty()
+                .hasValue(refreshToken);
+    }
+
+    private void checkException(
+            String url,
+            BiFunction<String, String, RequestBuilder> requestFunction,
+            Function<User, String> createNewTokenFunction
+    ) throws Exception {
+
+        // token 이 없을 때
+        ErrorCode err = NoTokenExistsException.EXCEPTION.getErrorCode();
+
+        mvc.perform(requestFunction.apply(url, ""))
+                .andExpect(status().is(err.getStatus()))
+                .andExpect(content().string(containsString(err.getReason())));
+
+        // invalid 한 토큰이 주어졌을 때
+        err = InvalidTokenException.EXCEPTION.getErrorCode();
+
+        mvc.perform(requestFunction.apply(url, "RandomInvalidToken"))
+                .andExpect(status().is(err.getStatus()))
+                .andExpect(content().string(containsString(err.getReason())));
+
+        // 토큰은 유효하지만 연관되는 유저가 없을 때
+        err = NoUserFoundViaTokenException.Exception.getErrorCode();
+        String newToken = createNewTokenFunction.apply(testUser);
+        userRepo.delete(testUser);
+
+        mvc.perform(requestFunction.apply(url, newToken))
+                .andExpect(status().is(err.getStatus()))
+                .andExpect(content().string(containsString(err.getReason())));
+    }
+}

--- a/src/test/java/com/palettee/global/security/jwt/controllers/TokenControllerTest.java
+++ b/src/test/java/com/palettee/global/security/jwt/controllers/TokenControllerTest.java
@@ -47,17 +47,21 @@ class TokenControllerTest {
 
     @BeforeEach
     void setUp() {
-        testUser = userRepo.save(
-                User.builder()
-                        .email("test@test.com")
-                        .build()
-        );
+        try {
+            testUser = userRepo.save(
+                    User.builder()
+                            .email("test@test.com")
+                            .build()
+            );
+        } catch (Exception e) {
+            testUser = userRepo.findByEmail(testUser.getEmail()).orElseThrow();
+        }
     }
 
     @AfterEach
     void remove() {
         redisService.deleteRefreshToken(testUser);
-        userRepo.delete(testUser);
+        userRepo.deleteAll();
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,3 +16,9 @@ redis:
   host: localhost
   port: 6379
   password: abcdefg
+
+server:
+  servlet:
+    encoding:
+      charset: utf-8
+      force: true


### PR DESCRIPTION
# #️⃣연관된 이슈

Close: #23 

# 📝작업 내용

#### 1. `Refresh` 토큰을 저장하기 위한 `RedisService` 를 추가하였습니다.

#### 2. 기존 `SecurityConfig` 에 API 별 권한 설정을 추가하였습니다.

#### 3. `JwtFilter` 를 추가하였습니다. 
확인하니 `GlobalExceptionHandler` 가 filter 단에는 적용되지 않아 아래 내용을 추가했습니다.
- `JwtExceptionHandlingFilter` : `JwtFilter` 에서 에러 발생하면 handling 하는 filter
- `JwtAccessDeniedHandler` : Security context 에 넣은 권한보다 더 높은 권한이 필요할 때 작동하는 handler

특히 `JwtFilter` 에 `request uri`, `http method` 에 따라 filter 를 우회하는 로직을 추가하였습니다.

#### 4. 토큰 발급과 관련된 `TokenController` 를 추가하였습니다.
개발 중 토큰 발급 편의를 위한 `/token//test-issue?userEmail=?` endpoint 를 추가하였습니다.
유저 이메일을 제공해 쉽게 토큰 발급이 가능합니다. 

# 💬리뷰 요구사항

개발하다보니 너무 많은 내용이 한번에 들어간 것 같습니다.
너무 많다 느끼시면 분할해서 `PR` 다시 만들도록 하겠습니다.
