### PR TITLE
#48 Hotfix - 유저 프로필 이미지 `URL` `DB` 저장 추가

### DIFF
--- a/src/main/java/com/palettee/user/controller/dto/request/RegisterBasicInfoRequest.java
+++ b/src/main/java/com/palettee/user/controller/dto/request/RegisterBasicInfoRequest.java
@@ -31,7 +31,11 @@ public record RegisterBasicInfoRequest(
         String division,
 
         @Size(max = 5, message = "연관 링크는 최대 5개 까지 가능합니다.")
-        List<String> url
+        List<String> url,
+
+        // 정보 등록 전 사용자가 S3 에 업로드한 이미지 링크들
+        // imageUrl 도 여기에 포함되어야 함.
+        List<String> s3StoredImageUrls
 ) {
 
 }

--- a/src/main/java/com/palettee/user/domain/StoredProfileImageUrl.java
+++ b/src/main/java/com/palettee/user/domain/StoredProfileImageUrl.java
@@ -1,0 +1,26 @@
+package com.palettee.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoredProfileImageUrl {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public StoredProfileImageUrl(String url, User user) {
+        this.url = url;
+        this.user = user;
+        user.addStoredProfileImageUrl(this);
+    }
+}

--- a/src/main/java/com/palettee/user/domain/User.java
+++ b/src/main/java/com/palettee/user/domain/User.java
@@ -133,6 +133,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private final List<Archive> archives = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private final List<StoredProfileImageUrl> storedProfileImageUrls = new ArrayList<>();
+
     @Builder
     public User(
             String oauthIdentity, UserRole userRole,
@@ -165,6 +168,10 @@ public class User {
 
     public void addArchive(Archive archive) {
         this.archives.add(archive);
+    }
+
+    public void addStoredProfileImageUrl(StoredProfileImageUrl storedProfileImageUrl) {
+        this.storedProfileImageUrls.add(storedProfileImageUrl);
     }
 
     public User(String email, String imageUrl, String name, String briefIntro, MajorJobGroup majorJobGroup, MinorJobGroup minorJobGroup) {

--- a/src/main/java/com/palettee/user/repository/StoredProfileImageUrlRepository.java
+++ b/src/main/java/com/palettee/user/repository/StoredProfileImageUrlRepository.java
@@ -1,0 +1,12 @@
+package com.palettee.user.repository;
+
+import com.palettee.user.domain.*;
+import java.util.*;
+import org.springframework.data.jpa.repository.*;
+
+public interface StoredProfileImageUrlRepository
+        extends JpaRepository<StoredProfileImageUrl, Long> {
+
+    @Query("select url from StoredProfileImageUrl url where url.user.id = :userId")
+    List<StoredProfileImageUrl> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/palettee/user/service/BasicRegisterService.java
+++ b/src/main/java/com/palettee/user/service/BasicRegisterService.java
@@ -25,6 +25,7 @@ public class BasicRegisterService {
     private final UserRepository userRepo;
     private final RelatedLinkRepository relatedLinkRepo;
     private final PortFolioRepository portFolioRepo;
+    private final StoredProfileImageUrlRepository storedProfileImageUrlRepo;
 
     /**
      * 유저 기본 정보 등록시 기초 정보 보여주기
@@ -64,6 +65,14 @@ public class BasicRegisterService {
 
         // 기본 정보 등록했으니까 권한 상승
         user.changeUserRole(UserRole.JUST_NEWBIE);
+
+        // 사용자가 S3 에 업로드한 자원들 추가
+        List<String> s3Resources = registerBasicInfoRequest.s3StoredImageUrls();
+        if (s3Resources != null && !s3Resources.isEmpty()) {
+            for (String s3Resource : s3Resources) {
+                storedProfileImageUrlRepo.save(new StoredProfileImageUrl(s3Resource, user));
+            }
+        }
 
         log.info("Registered basic user info on id: {}",
                 user.getId());

--- a/src/test/java/com/palettee/user/controller/BasicRegisterControllerTest.java
+++ b/src/test/java/com/palettee/user/controller/BasicRegisterControllerTest.java
@@ -85,7 +85,7 @@ class BasicRegisterControllerTest {
             List<String> urls) {
         return new RegisterBasicInfoRequest(
                 "이름", "자기소개", "test-image-url.com", major, minor,
-                "타이틀", div, urls
+                "타이틀", div, urls, null
         );
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Close: #48 

## 📝작업 내용

사용자 S3 에 업로드한 프로필 이미지 URL 을 기록하도록 기존 코드를 개선하였습니다.

`유저 정보 수정` 시에도 비슷하게 작업할 것 같은데, `유저 정보 수정` 은 지금 작업하는 부분과 맞물려 있어 
개선 후 통합적으로 `PR` 올리겠습니다.