### PR TITLE
`[Hotfix]` - 유저 정보 수정 시 `LazyInitializationException` 문제 해결

### DIFF
--- a/src/main/java/com/palettee/user/repository/UserRepository.java
+++ b/src/main/java/com/palettee/user/repository/UserRepository.java
@@ -3,7 +3,7 @@ package com.palettee.user.repository;
 import com.palettee.user.domain.*;
 import java.util.*;
 import org.springframework.data.jpa.repository.*;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.query.*;
 
 public interface UserRepository
         extends JpaRepository<User, Long> {
@@ -14,4 +14,13 @@ public interface UserRepository
 
     @Query("select u.name from User u where u.id = :targetId")
     String getUsername(@Param("targetId") Long targetId);
+
+    @Query("select u from User u left join fetch u.relatedLinks where u.id = :userId")
+    Optional<User> findByIdFetchWithRelatedLinks(Long userId);
+
+    @Query("select u from User u left join fetch u.portfolios where u.id = :userId")
+    Optional<User> findByIdFetchWithPortfolios(Long userId);
+
+    @Query("select u from User u left join fetch u.storedProfileImageUrls where u.id = :userId")
+    Optional<User> findByIdFetchWithStoredProfileUrls(Long userId);
 }

--- a/src/main/java/com/palettee/user/service/BasicRegisterService.java
+++ b/src/main/java/com/palettee/user/service/BasicRegisterService.java
@@ -51,9 +51,12 @@ public class BasicRegisterService {
 
         // url 제외 정보 등록
         user = this.getUser(user.getEmail());
-        user = user.update(registerBasicInfoRequest);
+        user.update(registerBasicInfoRequest);
+        user.changeUserRole(UserRole.JUST_NEWBIE);
 
         log.debug("Registered user {}'s basic info", user.getId());
+
+        user = this.getUserByIdFetchWithRelatedLinks(user.getId());
 
         // 이전 저장되 있던 url 제거
         relatedLinkRepo.deleteAllByUserId(user.getId());
@@ -67,8 +70,7 @@ public class BasicRegisterService {
             log.debug("Registered user {}'s social links", user.getId());
         }
 
-        // 기본 정보 등록했으니까 권한 상승
-        user.changeUserRole(UserRole.JUST_NEWBIE);
+        user = this.getUserByIdFetchWithStoredImageUrls(user.getId());
 
         // 사용자가 S3 에 업로드한 자원들 추가
         List<String> s3Resources = registerBasicInfoRequest.s3StoredImageUrls();
@@ -94,6 +96,9 @@ public class BasicRegisterService {
     ) {
 
         user = this.getUser(user.getEmail());
+        user.changeUserRole(UserRole.OLD_NEWBIE);
+
+        user = this.getUserByIdFetchWithPortfolio(user.getId());
 
         // 이전 포폴 정보 삭제
         portFolioRepo.deleteAllByUserId(user.getId());
@@ -104,9 +109,6 @@ public class BasicRegisterService {
         String url = registerPortfolioRequest.portfolioUrl();
         portFolioRepo.save(new PortFolio(user, url));
 
-        // 권한 상승
-        user.changeUserRole(UserRole.OLD_NEWBIE);
-
         log.info("Registered user portfolio info on id: {}",
                 user.getId());
 
@@ -115,6 +117,21 @@ public class BasicRegisterService {
 
     private User getUser(String email) {
         return userRepo.findByEmail(email)
+                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
+
+    private User getUserByIdFetchWithRelatedLinks(Long userId) throws UserNotFoundException {
+        return userRepo.findByIdFetchWithRelatedLinks(userId)
+                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
+
+    private User getUserByIdFetchWithPortfolio(Long userId) throws UserNotFoundException {
+        return userRepo.findByIdFetchWithPortfolios(userId)
+                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
+
+    private User getUserByIdFetchWithStoredImageUrls(Long userId) throws UserNotFoundException {
+        return userRepo.findByIdFetchWithStoredProfileUrls(userId)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

유저 정보 수정시 `LazyInitializationException` 이 발생하는 버그를 해결하였습니다.

에러가 발생하던 endpoint :
- `POST - /profile, /portfolio` : 자신의 기본, 포폴 정보를 등록하는 요청
- `PUT - /user/{userId}/edit` : 자신의 프로필 정보를 수정하는 요청

### 에러 원인 : 
`User` 의 `portfolios`, `relatedLinks` 등이 `FetchType.LAZY` 로 로딩되지 않은 상태에서 정보를 수정하려 시도해 에러가 발생하였습니다.

### 해결한 방법 : 
`portfolios` 등을 `join fetch` 하는 메서드를 통해 `User` `Entity` 를 가져오고 정보를 수정하였습니다.
