### PR TITLE
fix: `EC2` / `local` 에서 `OAuth 2` 로그인 성공 redirect-uri 분리

### DIFF
--- a/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/palettee/global/security/oauth/handler/OAuth2LoginSuccessHandler.java
@@ -5,8 +5,8 @@ import com.palettee.global.security.oauth.*;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import java.io.*;
-import lombok.*;
 import lombok.extern.slf4j.*;
+import org.springframework.beans.factory.annotation.*;
 import org.springframework.security.core.*;
 import org.springframework.security.web.authentication.*;
 import org.springframework.stereotype.*;
@@ -16,11 +16,20 @@ import org.springframework.stereotype.*;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler
         extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtUtils jwtUtils;
+    private final String successRedirectUri;
+
+    public OAuth2LoginSuccessHandler(
+            JwtUtils jwtUtils,
+            @Value("${oauth-success-redirect-uri}") String successRedirectUri
+    ) {
+        this.jwtUtils = jwtUtils;
+        this.successRedirectUri = successRedirectUri;
+    }
+
 
     /**
      * 로그인 성공해서 임시 토큰으로 진짜 토큰들 발급하는 {@code /token/issue?token=} API 로 redirect
@@ -36,7 +45,8 @@ public class OAuth2LoginSuccessHandler
         log.info("Temporary token issued in CustomLoginSuccessHandler - token: {}", temporaryToken);
 
         // 임시 토큰으로 access, refresh 토큰 발급하는 endpoint 로 redirect
-        response.sendRedirect("/token/issue?token=" + temporaryToken);
+        // local profile 은 back 으로, deploy 는 프론트 주소로
+        response.sendRedirect(successRedirectUri + "?token=" + temporaryToken);
     }
 }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -33,6 +33,8 @@ spring:
           github:
             redirect-uri: http://localhost:8080/login/oauth2/code/github
 
+oauth-success-redirect-uri: /token/issue
+
 redis:
   host: localhost
   port: 6379

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,7 @@ spring:
   profiles:
     include: secret
 
+oauth-success-redirect-uri: /token/issue
 
 redis:
   host: localhost


### PR DESCRIPTION
## #️⃣연관된 이슈

Related: #69 

## 📝작업 내용

`local` 은 `/token/issue` endpoint 로 redirect 되어 바로 토큰 발급

`EC2` 에서는 프론트 사이트 `https://palettee22.netlify.app/login?token=???` 로 redirect.
프론트는 위 `token=???` 로 `/token/issue` 호출

---

### `application-ec2-dev.yml` 수정하였습니다.

