### PR TITLE
#68 - `[Feat/Enhance]` : 사소한 `User` API 추가 및 도메인 요청별 `log` 저장 기능 추가

### DIFF
--- a/src/main/java/com/palettee/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/palettee/global/exception/GlobalExceptionHandler.java
@@ -95,7 +95,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         String requestUrl = req.getRequestURL().toString();
 
         log.error("Exception has been occurred on REQUEST ID [{}] - [{} \"{}\"] : {}, {}",
-                requestUUID != null ? requestUrl : "UNKNOWN",
+                requestUUID != null ? requestUUID : "UNKNOWN",
                 httpMethod, requestUrl,
                 status, msg, e);
     }

--- a/src/main/java/com/palettee/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/palettee/global/exception/GlobalExceptionHandler.java
@@ -1,22 +1,15 @@
 package com.palettee.global.exception;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import com.palettee.global.logging.*;
+import jakarta.servlet.http.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.http.*;
+import org.springframework.validation.*;
+import org.springframework.web.bind.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.*;
+import org.springframework.web.servlet.mvc.method.annotation.*;
 
 @RestControllerAdvice
 @Slf4j
@@ -24,18 +17,25 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     // 예상했던 예외들 커스텀
     @ExceptionHandler(PaletteException.class)
-    public ResponseEntity<ErrorResponse> paletteExceptionHandler(PaletteException e) {
+    public ResponseEntity<ErrorResponse> paletteExceptionHandler(
+            PaletteException e, HttpServletRequest request
+    ) {
         ErrorCode code = e.getErrorCode();
         ErrorResponse errorResponse =
                 new ErrorResponse(
                         code.getStatus(),
                         code.getReason());
+
+        this.logError(request, code.getStatus(), code.getReason(), e);
+
         return ResponseEntity.status(HttpStatus.valueOf(code.getStatus())).body(errorResponse);
     }
 
     // 예상치 못했던 예외들은 500에러
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    protected ResponseEntity<ErrorResponse> handleException(
+            Exception e, HttpServletRequest request
+    ) {
         log.error("INTERNAL_SERVER_ERROR", e);
         ErrorCode internalServerError = ErrorCode.INTERNAL_SERVER_ERROR;
 
@@ -44,29 +44,59 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                         internalServerError.getStatus(),
                         internalServerError.getReason());
 
+        this.logError(request, internalServerError.getStatus(), internalServerError.getReason(), e);
+
         return ResponseEntity.status(HttpStatus.valueOf(internalServerError.getStatus()))
                 .body(errorResponse);
     }
 
-    // valid로 잡힌 예외들 커스텀
+    // @Valid 로 잡힌 예외들 커스텀
     @SneakyThrows
     @Override
-    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
-                                                                  HttpHeaders headers,
-                                                                  HttpStatusCode status,
-                                                                  WebRequest request) {
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
 
-        List<FieldError> errors = ex.getBindingResult().getFieldErrors();
-        Map<String, Object> fieldAndErrorMessages =
-                errors.stream()
-                        .collect(
-                                Collectors.toMap(
-                                        FieldError::getField, FieldError::getDefaultMessage));
+        // TODO : 지금 validation 에러가 응답으로 보이긴 하는데 이상함.
+        // 동일한 invalid body 여도 getDefaultMessage 했을 때 오는 메시지가 랜덤함. 어케 고치지???
+        // invalid 한 필드까지는 고정적인 것 같은데 어떤 메시지가 선택되는지가 매번 다름..
+        BindingResult bindingResult = ex.getBindingResult();
 
-        String errorsToJsonString = new ObjectMapper().writeValueAsString(fieldAndErrorMessages);
-        ErrorResponse errorResponse =
-                new ErrorResponse(status.value(), errorsToJsonString);
+        if (!bindingResult.hasErrors()) {
+            log.error(
+                    "Expected request body validation has error but it wasn't. "
+                            + "Unexpected validation detected.");
+        }
+
+        String message = bindingResult.getAllErrors().get(0).getDefaultMessage();
+        ErrorResponse errorResponse = new ErrorResponse(status.value(), message);
+
+        HttpServletRequest httpReq = ((ServletWebRequest) request).getRequest();
+
+        this.logError(httpReq, status.value(), message, ex);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * @see MDCLoggingFilter
+     */
+    private void logError(HttpServletRequest req, int status, String msg, Exception e) {
+
+        if (req == null) {
+            log.error("Exception has been occurred : {}, {}", status, msg, e);
+            return;
+        }
+
+        Object requestUUID = req.getAttribute("custom-request-uuid");
+        String httpMethod = req.getMethod();
+        String requestUrl = req.getRequestURL().toString();
+
+        log.error("Exception has been occurred on REQUEST ID [{}] - [{} \"{}\"] : {}, {}",
+                requestUUID != null ? requestUrl : "UNKNOWN",
+                httpMethod, requestUrl,
+                status, msg, e);
     }
 }

--- a/src/main/java/com/palettee/global/logging/DomainType.java
+++ b/src/main/java/com/palettee/global/logging/DomainType.java
@@ -1,0 +1,41 @@
+package com.palettee.global.logging;
+
+import java.util.*;
+import lombok.*;
+
+/**
+ * 요청 {@code URI} 로 어떤 도메인 요청인 판별하기위한 편의용 {@code enum} 상수
+ */
+@RequiredArgsConstructor
+public enum DomainType {
+    ARCHIVE("/archive"), CHAT("/chat"),
+    GATHERING("/gathering"), NOTIFICATION("/notification"),
+    PORTFOLIO("/portFolio"), USER("/user"), OTHER("/other");
+
+    private final String domainLogDir;
+
+    public String getDomainLogDir() {
+        // 맨 앞에 `/` 떼서 주기
+        return domainLogDir.substring(1);
+    }
+
+    public static DomainType of(String uri) {
+
+        // 특별 케이스들
+        // 토큰 발급, 초기 정보 등록, 제보 request
+        if (uri.startsWith("/token") || uri.startsWith("/profile") || uri.startsWith("/report")) {
+            return USER;
+        }
+
+        // 채팅방, 웹소켓 request
+        if (uri.startsWith("/chat-room") || uri.startsWith("/ws")) {
+            return CHAT;
+        }
+
+        // 나머지
+        return Arrays.stream(DomainType.values())
+                .filter(d -> uri.startsWith(d.domainLogDir))
+                .findFirst()
+                .orElse(OTHER);
+    }
+}

--- a/src/main/java/com/palettee/global/logging/MDCLoggingFilter.java
+++ b/src/main/java/com/palettee/global/logging/MDCLoggingFilter.java
@@ -1,0 +1,56 @@
+package com.palettee.global.logging;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
+import java.io.*;
+import java.util.*;
+import lombok.extern.slf4j.*;
+import org.slf4j.*;
+import org.springframework.core.*;
+import org.springframework.core.annotation.*;
+import org.springframework.stereotype.*;
+import org.springframework.web.filter.*;
+
+/**
+ * {@code Mapped Diagnostic Context} 이용한 도메인별 로그 저장(은 아니긴 한데 비슷한) {@code filter}
+ */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)  // 이러면 filter 중에서도 가장 빠른? 필터로 되는듯. 신기하네
+public class MDCLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 요청별 랜덤 uuid 생성 & 저장
+        String requestUUID = UUID.randomUUID().toString();
+        request.setAttribute("custom-request-uuid", requestUUID);
+        log.info("custom-request-uuid {} has been set to request {} \"{}\"",
+                requestUUID, request.getMethod(), request.getRequestURI());
+
+        try {
+
+            this.configureLogDirViaUri(request);
+            log.info("============== REQUEST [{}] START ==============", requestUUID);
+            filterChain.doFilter(request, response);
+
+        } finally {
+            log.info("============== REQUEST [{}] END ==============", requestUUID);
+            MDC.clear();
+        }
+    }
+
+    // uri 별 도메인 파악해서 MDC key 넣어주기
+    private void configureLogDirViaUri(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        DomainType domainType = DomainType.of(uri);
+
+        MDC.put("DOMAIN_LOG_DIR", domainType.getDomainLogDir());
+
+        log.info("Domain logging directory has been set to : [{}]", domainType.getDomainLogDir());
+    }
+}

--- a/src/main/java/com/palettee/user/controller/dto/response/users/SimpleUserResponse.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/SimpleUserResponse.java
@@ -1,0 +1,17 @@
+package com.palettee.user.controller.dto.response.users;
+
+import com.palettee.user.domain.*;
+
+public record SimpleUserResponse(
+        Long userId,
+        String name,
+        String imageUrl,
+        UserRole role
+) {
+
+    public static SimpleUserResponse of(User user) {
+        return new SimpleUserResponse(
+                user.getId(), user.getName(), user.getImageUrl(), user.getUserRole()
+        );
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -40,4 +40,6 @@ redis:
   port: 6379
   password:
 
-  environment: local
+LOG_DIR: ./logs
+
+environment: local

--- a/src/main/resources/logback-appender.xml
+++ b/src/main/resources/logback-appender.xml
@@ -1,0 +1,64 @@
+<configuration>
+
+  <!-- property 에서 값 읽어오기 : 프로필별 로그 저장 위치 -->
+  <!-- 로컬에서는 ./logs, EC2 에서는 ~/logs -->
+  <springProperty name="LOG_DIR" source="LOG_DIR"/>
+
+  <!-- 오늘 날짜, 로그 패턴 -->
+  <timestamp key="TODAY" datePattern="yyyy-MM-dd"/>
+  <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"/>
+
+
+  <!-- 콘솔 로그 보이게 하는 appender -->
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+
+  <!-- 요청 domain 별 로그 분리해 저장하는 sifting appender -->
+  <appender name="PER-REQUEST" class="ch.qos.logback.classic.sift.SiftingAppender">
+    <discriminator class="ch.qos.logback.classic.sift.MDCBasedDiscriminator">
+      <key>DOMAIN_LOG_DIR</key>   <!-- 도메인 로그별 폴더 명, MDC 로 설정됨 -->
+      <defaultValue>other</defaultValue>
+    </discriminator>
+
+    <sift>
+      <appender name="FILE-${DOMAIN_LOG_DIR}"
+        class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+          <fileNamePattern>${LOG_DIR}/${DOMAIN_LOG_DIR}/%d{yyyy-MM-dd}_%i.log
+          </fileNamePattern>
+          <maxFileSize>10MB</maxFileSize>
+          <maxHistory>14</maxHistory>
+          <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+
+        <encoder>
+          <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+      </appender>
+    </sift>
+  </appender>
+
+
+  <!-- 에러난 부분만 편하게 볼 수 있도록 집계하는 appender -->
+  <appender name="EXCEPTION" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_DIR}/exceptions/%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+      <maxFileSize>5MB</maxFileSize>
+      <maxHistory>21</maxHistory>
+      <cleanHistoryOnStart>true</cleanHistoryOnStart>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n%ex
+      </pattern> <!-- '%ex' 는 stack trace 도 포함한다 캄 -->
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>ERROR</level>
+    </filter>
+  </appender>
+
+
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<configuration>
+
+  <!-- xml 에서 appender 가져오기 -->
+  <include resource="logback-appender.xml"/>
+
+
+  <!-- ROOT 로그 찍히는거 reference. 솔직히 뭔지 잘 모르겠음. -->
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="PER-REQUEST"/>
+  </root>
+
+
+  <!-- 우리 모듈에서 error 나는거 reference -->
+  <logger name="com.palettee" level="ERROR" additivity="true">
+    <appender-ref ref="EXCEPTION"/>
+  </logger>
+
+
+  <!-- hibernate 쿼리도 도메인별 로그에 저장되도록 추가 -->
+  <logger name="org.hibernate.SQL" level="DEBUG">
+    <appender-ref ref="PER-REQUEST"/>
+  </logger>
+
+</configuration>

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,3 +31,5 @@ server:
 
 sse:
   timeout: 3600000 # 1시간
+
+LOG_DIR: ./test-logs


### PR DESCRIPTION
## #️⃣연관된 이슈

Close: #68 

## 📝작업 내용

프론트에서 추가로 요구한 API 를 구현하였고, 요청 도메인별 로그 저장 기능을 추가하였습니다.

---

### 구현한 API
- `GET "/user/my-info"` : `Access` 토큰으로 자신의 정보를 조회

- `POST "/user/logout"` : 로그아웃 처리

---

### 요청 도메인별 로그 저장

요청별 분리되는 도메인과 그 기준은 다음과 같습니다.
- `archive` : `/archive` 로 시작하는 요청들
- `chat` : `/chat`, `/chat-room`, `/ws` 로 시작하는 요청들
- `gathering` : `/gathering` 로 시작하는 요청들
- `notification` : `/notification` 로 시작하는 요청들
- `portFolio` : `/portFolio` 로 시작하는 요청들
- `user` : `/user`, `/token`, `/profile`, `/report` 로 시작하는 요청들

- `other` : 그 외

모든 요청은 백엔드에 들어올 시 **요청마다 고유한 UUID** 를 발급받습니다. 이를 통해 요청의 시작, 종료, 에러 등을 빠르게 확인할 수 있습니다. `(아래 예시 참고)`

```
Domain logging directory has been set to : [user]
============== REQUEST [cffaf780-d762-43b5-9753-93b52c4ef7b9] START ==============
Request uri: POST - /token/reissue

(생략)

ERROR - Token is empty.
Using @ExceptionHandler com.palettee.global.exception.GlobalExceptionHandler#paletteExceptionHandler(PaletteException, HttpServletRequest)
Exception has been occurred on REQUEST ID [cffaf780-d762-43b5-9753-93b52c4ef7b9] - [POST "http://localhost/token/reissue"] : 401, 토큰이 존재하지 않습니다.
com.palettee.global.security.jwt.exceptions.NoTokenExistsException: null

(아주 긴 stack trace)

Resolved [com.palettee.global.security.jwt.exceptions.NoTokenExistsException]
============== REQUEST [cffaf780-d762-43b5-9753-93b52c4ef7b9] END ==============
```

또한 요청 시 에러 로그가 찍혔을 경우 위처럼 도메인별 로그에도 저장되지만, 특별히 `exceptions` 폴더에**도** 기록되게 하였습니다.

```
2024-12-04 01:55:48.775 ERROR c.p.g.s.jwt.services.TokenService - Token is empty.
2024-12-04 01:55:48.777 ERROR c.p.g.e.GlobalExceptionHandler - Exception has been occurred on REQUEST ID [cffaf780-d762-43b5-9753-93b52c4ef7b9] - [POST "http://localhost/token/reissue"] : 401, 토큰이 존재하지 않습니다.
com.palettee.global.security.jwt.exceptions.NoTokenExistsException: null

(생략)
```

`local` 프로필에서는 `./logs` 에, `test` 시 `./test-logs` 폴더에 로그를 저장하도록 만들었고,
`EC2` 프로필에서는 `/home/palettee-service-logs` 폴더에 저장하게할 예정입니다.

---

### 스크린샷 (선택)

- test 실행시 `./test-logs` 에 로그가 저장된 모습
<img width="1577" alt="스크린샷 2024-12-04 02 19 40" src="https://github.com/user-attachments/assets/3543615c-bb8a-4c6b-bbfe-e0cc63a0d3ae">

- `exceptions` 로그에도 동일한 에러가 기록된 모습
<img width="1577" alt="스크린샷 2024-12-04 02 20 34" src="https://github.com/user-attachments/assets/658a5167-69c0-440e-8d88-579a7601d4e7">

