### PR TITLE
`[Hotfix]` - `Refresh` 토큰으로 재발급 요청시 `NullPointException` 해결, `CORS` config 빠르게 Cherry pick

### DIFF
--- a/src/main/java/com/palettee/global/configs/CorsConfig.java
+++ b/src/main/java/com/palettee/global/configs/CorsConfig.java
@@ -16,11 +16,12 @@ public class CorsConfig {
         CorsConfiguration config = new CorsConfiguration();
 
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000", "https://palettee22.netlify.app", "https://palettee.site"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", "https://palettee22.netlify.app", "https://www.palettee.site"));
         config.addAllowedMethod("*");
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("*"));
-
+        // 클라이언트에서 접근할 수 있도록 노출할 헤더를 명시
+        config.setExposedHeaders(List.of("Authorization", "Content-Type", "Cache-Control"));
 
 
 

--- a/src/main/java/com/palettee/global/security/jwt/controllers/TokenController.java
+++ b/src/main/java/com/palettee/global/security/jwt/controllers/TokenController.java
@@ -101,11 +101,12 @@ public class TokenController {
     private String getRefreshTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
 
-        return Arrays.stream(cookies).parallel()
-                .filter(cookie -> cookie.getName().equals(REFRESH_TOKEN_COOKIE_KEY))
-                .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
+        return cookies == null ? null :
+                Arrays.stream(cookies).parallel()
+                        .filter(cookie -> cookie.getName().equals(REFRESH_TOKEN_COOKIE_KEY))
+                        .map(Cookie::getValue)
+                        .findFirst()
+                        .orElse(null);
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

`Refresh` 토큰으로 재발급 요청시 쿠키가 존재하지 않아 발생하는 `NullPointException` 을 해결하였고,
빠르게 `CORS` config `cherry pick` 하였습니다.

그래서 성원님 `PR` 여유롭게 리뷰하셔도 될 것 같습니다