### PR TITLE
hotfix: 유저 정보 수정시 연관 링크 `socials` 로 명칭 변경

### DIFF
--- a/src/main/java/com/palettee/user/controller/dto/request/users/EditUserInfoRequest.java
+++ b/src/main/java/com/palettee/user/controller/dto/request/users/EditUserInfoRequest.java
@@ -34,7 +34,7 @@ public record EditUserInfoRequest(
         String portfolioLink,
 
         @Size(max = 5, message = "연관 링크는 최대 5개 까지 가능합니다.")
-        List<String> url,
+        List<String> socials,
 
         // 정보 등록 전 사용자가 S3 에 업로드한 이미지 링크들
         // imageUrl 도 여기에 포함되어야 함.

--- a/src/main/java/com/palettee/user/controller/dto/request/users/RegisterBasicInfoRequest.java
+++ b/src/main/java/com/palettee/user/controller/dto/request/users/RegisterBasicInfoRequest.java
@@ -31,7 +31,7 @@ public record RegisterBasicInfoRequest(
         String division,
 
         @Size(max = 5, message = "연관 링크는 최대 5개 까지 가능합니다.")
-        List<String> url,
+        List<String> socials,
 
         // 정보 등록 전 사용자가 S3 에 업로드한 이미지 링크들
         // imageUrl 도 여기에 포함되어야 함.

--- a/src/main/java/com/palettee/user/service/BasicRegisterService.java
+++ b/src/main/java/com/palettee/user/service/BasicRegisterService.java
@@ -49,7 +49,7 @@ public class BasicRegisterService {
             RegisterBasicInfoRequest registerBasicInfoRequest)
             throws InvalidDivisionException, InvalidJobGroupException, JobGroupMismatchException {
 
-        // url 제외 정보 등록
+        // 일단 기본 정보만 등록
         user = this.getUser(user.getEmail());
         user.update(registerBasicInfoRequest);
         user.changeUserRole(UserRole.JUST_NEWBIE);
@@ -58,15 +58,15 @@ public class BasicRegisterService {
 
         user = this.getUserByIdFetchWithRelatedLinks(user.getId());
 
-        // 이전 저장되 있던 url 제거
+        // 이전 저장되 있던 socials 제거
         relatedLinkRepo.deleteAllByUserId(user.getId());
 
         log.debug("Deleted user {}'s all social links", user.getId());
 
-        // url (linkedin, 블로그 등) 정보 등록
-        List<String> links = registerBasicInfoRequest.url();
-        // url 등록 되었으면 로그 찍기
-        if (this.registerUrlsOn(user, links, relatedLinkRepo::save, RelatedLink::new)) {
+        // socials (linkedin, 블로그 등) 정보 등록
+        List<String> socialLinks = registerBasicInfoRequest.socials();
+        // socials 등록 되었으면 로그 찍기
+        if (this.registerUrlsOn(user, socialLinks, relatedLinkRepo::save, RelatedLink::new)) {
             log.debug("Registered user {}'s social links", user.getId());
         }
 

--- a/src/main/java/com/palettee/user/service/UserService.java
+++ b/src/main/java/com/palettee/user/service/UserService.java
@@ -155,12 +155,12 @@ public class UserService {
 
         userOnTarget = this.getUserByIdFetchWithRelatedLinks(userId);
 
-        // 이전 저장되 있던 url 제거
+        // 일단 기본 정보만 등록
         relatedLinkRepo.deleteAllByUserId(userOnTarget.getId());
         log.debug("Deleted user {}'s all social links", userOnTarget.getId());
 
-        // url (linkedin, 블로그 등) 정보 등록
-        List<String> links = editUserInfoRequest.url();
+        // socials (linkedin, 블로그 등) 정보 등록
+        List<String> links = editUserInfoRequest.socials();
         // 등록 되었다면 log 찍기
         if (this.registerUrlsOn(userOnTarget, links,
                 relatedLinkRepo::save, RelatedLink::new)) {

--- a/src/test/java/com/palettee/user/controller/BasicRegisterControllerTest.java
+++ b/src/test/java/com/palettee/user/controller/BasicRegisterControllerTest.java
@@ -141,7 +141,7 @@ class BasicRegisterControllerTest {
 
         this.checkValidationException("/profile", jobGroupMismatch, divisionMismatch);
 
-        // url 5 개 초과 주어졌을 때
+        // socials 5 개 초과 주어졌을 때
         var tooManyUrl = gen("developer", "backend", "student",
                 List.of("111.com", "222.com", "333.com", "444.com", "555.com", "666.com"));
 

--- a/src/test/java/com/palettee/user/controller/UserControllerTest.java
+++ b/src/test/java/com/palettee/user/controller/UserControllerTest.java
@@ -311,7 +311,7 @@ class UserControllerTest {
 
         this.checkValidationException(BASE_URL + "/edit", jobGroupMismatch, divisionMismatch);
 
-        // url 5 개 초과 주어졌을 때
+        // socials 5 개 초과 주어졌을 때
         var tooManyUrl = genReq("developer", "backend", "student",
                 List.of("111.com", "222.com", "333.com", "444.com", "555.com", "666.com"));
 

--- a/src/test/java/com/palettee/user/service/BasicRegisterServiceTest.java
+++ b/src/test/java/com/palettee/user/service/BasicRegisterServiceTest.java
@@ -159,13 +159,13 @@ class BasicRegisterServiceTest {
         assertThat(majorGroup).isEqualTo(user.getMajorJobGroup());
         assertThat(minorGroup).isEqualTo(user.getMinorJobGroup());
 
-        // url 도 변경 됐는지 확인
+        // socials 도 변경 됐는지 확인
         List<String> relatedLinks = user.getRelatedLinks()
                 .stream()
                 .map(RelatedLink::getLink)
                 .sorted()
                 .toList();
-        List<String> requestLinks = BasicRegisterServiceTest.registerBasicInfoRequest.url()
+        List<String> requestLinks = BasicRegisterServiceTest.registerBasicInfoRequest.socials()
                 .stream()
                 .sorted()
                 .toList();

--- a/src/test/java/com/palettee/user/service/UserServiceTest.java
+++ b/src/test/java/com/palettee/user/service/UserServiceTest.java
@@ -495,7 +495,7 @@ class UserServiceTest {
         url = url.stream().sorted().toList();
         s3Urls = s3Urls.stream().sorted().toList();
 
-        assertThat(url).isEqualTo(request.url().stream().sorted().toList());
+        assertThat(url).isEqualTo(request.socials().stream().sorted().toList());
         assertThat(s3Urls).isEqualTo(request.s3StoredImageUrls().stream().sorted().toList());
 
         log.info("User info were successfully edited.");


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용

유저 정보 수정시 연관 링크 `socials` 로 명칭 변경
