### PR TITLE
#115 - Fix/Enhance : 응답 데이터 추가 및 `아카이브 색상 통계` API 추가

### DIFF
--- a/src/main/java/com/palettee/archive/repository/ArchiveRepository.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveRepository.java
@@ -1,12 +1,11 @@
 package com.palettee.archive.repository;
 
-import com.palettee.archive.controller.dto.response.ColorCount;
+import com.palettee.archive.controller.dto.response.*;
 import com.palettee.archive.domain.*;
-import java.util.List;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+import java.util.*;
+import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.query.*;
 
 public interface ArchiveRepository extends JpaRepository<Archive, Long>, ArchiveCustomRepository {
 
@@ -28,4 +27,6 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long>, Archive
     @Query("SELECT a.type AS type, COUNT(a) AS count FROM Archive a where a.id in :ids GROUP BY a.type")
     List<ColorCount> countLikeArchiveByArchiveType(@Param("ids") List<Long> ids);
 
+    @Query("SELECT a FROM Archive a where a.user.id = :userId")
+    List<Archive> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/palettee/gathering/repository/GatheringRepositoryCustom.java
+++ b/src/main/java/com/palettee/gathering/repository/GatheringRepositoryCustom.java
@@ -1,11 +1,9 @@
 package com.palettee.gathering.repository;
 
-import com.palettee.gathering.controller.dto.Response.*;
 import com.palettee.portfolio.controller.dto.response.*;
 import com.palettee.user.controller.dto.response.users.*;
+import java.util.*;
 import org.springframework.data.domain.*;
-
-import java.util.List;
 
 public interface GatheringRepositoryCustom {
 
@@ -33,7 +31,7 @@ public interface GatheringRepositoryCustom {
      * @param size            가져올 게더링 개수
      * @param gatheringOffset 이전 조회에서 제공된 {@code nextGatheringId}
      */
-    GetUserGatheringResponse findGatheringsOnUserWithNoOffset(
+    GatheringPagingDTO findGatheringsOnUserWithNoOffset(
             Long userId, int size,
             Long gatheringOffset
     );

--- a/src/main/java/com/palettee/gathering/repository/GatheringRepositoryImpl.java
+++ b/src/main/java/com/palettee/gathering/repository/GatheringRepositoryImpl.java
@@ -1,25 +1,24 @@
 package com.palettee.gathering.repository;
 
 
-import com.palettee.gathering.controller.dto.Response.GatheringResponse;
+import static com.palettee.gathering.domain.QGathering.*;
+import static com.palettee.gathering.domain.QPosition.*;
+import static com.palettee.likes.domain.QLikes.*;
+import static com.palettee.user.domain.QUser.*;
+
+import com.palettee.gathering.controller.dto.Response.*;
+import com.palettee.gathering.domain.Sort;
 import com.palettee.gathering.domain.*;
-import com.palettee.likes.domain.LikeType;
-import com.palettee.portfolio.controller.dto.response.CustomSliceResponse;
-import com.palettee.user.controller.dto.response.users.GetUserGatheringResponse;
-import com.querydsl.core.Tuple;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
-
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.palettee.gathering.domain.QGathering.gathering;
-import static com.palettee.gathering.domain.QPosition.position;
-import static com.palettee.likes.domain.QLikes.likes;
-import static com.palettee.user.domain.QUser.user;
+import com.palettee.likes.domain.*;
+import com.palettee.portfolio.controller.dto.response.*;
+import com.palettee.user.controller.dto.response.users.*;
+import com.querydsl.core.*;
+import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.impl.*;
+import java.util.*;
+import java.util.stream.*;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.*;
 
 @Repository
 public class GatheringRepositoryImpl implements GatheringRepositoryCustom {
@@ -117,7 +116,7 @@ public class GatheringRepositoryImpl implements GatheringRepositoryCustom {
      * {@inheritDoc}
      */
     @Override
-    public GetUserGatheringResponse findGatheringsOnUserWithNoOffset(
+    public GatheringPagingDTO findGatheringsOnUserWithNoOffset(
             Long userId, int size,
             Long gatheringOffset
     ) {
@@ -144,7 +143,7 @@ public class GatheringRepositoryImpl implements GatheringRepositoryCustom {
                     .toList();
         }
 
-        return GetUserGatheringResponse.of(
+        return GatheringPagingDTO.of(
                 searchResult, hasNext, nextOffset
         );
     }

--- a/src/main/java/com/palettee/global/configs/SecurityConfig.java
+++ b/src/main/java/com/palettee/global/configs/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 
                 // 유저의 프로필, 아카이브, 게더링 조회
                 .conditionalByPassable("/user/{id}/profile", HttpMethod.GET)
-                .byPassable(HttpMethod.GET, "/user/{id}/archives", "/user/{id}/gatherings")
+                .byPassable(HttpMethod.GET,
+                        "/user/{id}/archive-colors", "/user/{id}/archives", "/user/{id}/gatherings")
 
                 // 유저 제보 목록, 상세 내용, 댓글 조회
                 .byPassable(HttpMethod.GET, "/report", "/report/{reportId}",

--- a/src/main/java/com/palettee/user/controller/UserController.java
+++ b/src/main/java/com/palettee/user/controller/UserController.java
@@ -107,9 +107,9 @@ public class UserController {
      *
      * @param id 조회하고자 하는 사용자의 id
      */
-    @GetMapping("/{id}/gatherings")
+    @GetMapping("/{userId}/gatherings")
     public GetUserGatheringResponse getUserGatherings(
-            @PathVariable("id") Long id,
+            @PathVariable("userId") Long id,
             @Min(1) @RequestParam("size") int size,
             @RequestParam(value = "nextGatheringId", required = false) Long nextGatheringId
     ) {

--- a/src/main/java/com/palettee/user/controller/UserController.java
+++ b/src/main/java/com/palettee/user/controller/UserController.java
@@ -74,6 +74,17 @@ public class UserController {
         return userService.editUserInfo(editUserInfoRequest, id, getUserFromContext());
     }
 
+    /**
+     * 유저가 작성한 아카이브들의 색상 통계를 조회
+     *
+     * @param id 아카이브 색상 통계 조회할 유저 id
+     */
+    @GetMapping("/{userId}/archive-colors")
+    public GetArchiveColorStatisticsResponse getArchiveColorStatistics(
+            @PathVariable("userId") Long id
+    ) {
+        return userService.getArchiveColorStatistics(id);
+    }
 
     /**
      * 특정 유저의 {@code Archive} 를 조회

--- a/src/main/java/com/palettee/user/controller/dto/response/users/GatheringPagingDTO.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/GatheringPagingDTO.java
@@ -1,0 +1,20 @@
+package com.palettee.user.controller.dto.response.users;
+
+import com.palettee.gathering.domain.*;
+import java.util.*;
+
+public record GatheringPagingDTO(
+        List<Gathering> gatherings,
+        boolean hasNext,
+        Long nextGatheringId
+) {
+
+    public static GatheringPagingDTO of(List<Gathering> gatheringList, boolean hasNext,
+            Long nextGatheringId) {
+
+        return new GatheringPagingDTO(
+                gatheringList,
+                hasNext, nextGatheringId
+        );
+    }
+}

--- a/src/main/java/com/palettee/user/controller/dto/response/users/GetArchiveColorStatisticsResponse.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/GetArchiveColorStatisticsResponse.java
@@ -1,0 +1,33 @@
+package com.palettee.user.controller.dto.response.users;
+
+import com.palettee.archive.domain.*;
+import java.util.*;
+import java.util.stream.*;
+
+public record GetArchiveColorStatisticsResponse(
+        long RED,
+        long YELLOW,
+        long GREEN,
+        long BLUE,
+        long PURPLE
+) {
+
+    public static GetArchiveColorStatisticsResponse of(List<Archive> archives) {
+
+        Map<ArchiveType, Long> colorMap = archives.stream()
+                .filter(archive -> !archive.getType().equals(ArchiveType.NO_COLOR))
+                .collect(Collectors.groupingBy(Archive::getType, Collectors.counting()));
+
+        return new GetArchiveColorStatisticsResponse(
+                getColor(colorMap, ArchiveType.RED),
+                getColor(colorMap, ArchiveType.YELLOW),
+                getColor(colorMap, ArchiveType.GREEN),
+                getColor(colorMap, ArchiveType.BLUE),
+                getColor(colorMap, ArchiveType.PURPLE)
+        );
+    }
+
+    private static long getColor(Map<ArchiveType, Long> colorMap, ArchiveType type) {
+        return colorMap.getOrDefault(type, 0L);
+    }
+}

--- a/src/main/java/com/palettee/user/controller/dto/response/users/GetUserGatheringResponse.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/GetUserGatheringResponse.java
@@ -1,6 +1,6 @@
 package com.palettee.user.controller.dto.response.users;
 
-import com.palettee.gathering.domain.*;
+import com.palettee.gathering.repository.*;
 import java.util.*;
 
 public record GetUserGatheringResponse(
@@ -10,13 +10,17 @@ public record GetUserGatheringResponse(
         Long nextGatheringId
 ) {
 
-    public static GetUserGatheringResponse of(List<Gathering> gatheringList, boolean hasNext,
-            Long nextGatheringId) {
+    public static GetUserGatheringResponse of(GatheringPagingDTO pagingDTO,
+            GatheringTagRepository gatheringTagRepo) {
 
-        List<SimpleGatheringInfo> gatherings = gatheringList.stream()
-                .map(SimpleGatheringInfo::of)
+        List<SimpleGatheringInfo> gatherings = pagingDTO.gatherings()
+                .stream()
+                .map(g -> SimpleGatheringInfo.of(g, gatheringTagRepo))
                 .toList();
 
-        return new GetUserGatheringResponse(gatherings, hasNext, nextGatheringId);
+        return new GetUserGatheringResponse(
+                gatherings,
+                pagingDTO.hasNext(), pagingDTO.nextGatheringId()
+        );
     }
 }

--- a/src/main/java/com/palettee/user/controller/dto/response/users/SimpleArchiveInfo.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/SimpleArchiveInfo.java
@@ -6,19 +6,30 @@ import java.util.*;
 public record SimpleArchiveInfo(
         Long archiveId,
         String title,
-        ArchiveType color,
-        String thumbnailImageUrl
+        String type,
+        String imageUrl,
+
+        String description,
+        String introduction,
+        boolean canComment,
+        String createDate
 ) {
 
     public static SimpleArchiveInfo of(Archive archive) {
         List<ArchiveImage> images = archive.getArchiveImages();
-        String thumbnail = images.stream()
+        String imageUrl = images.stream()
                 .map(ArchiveImage::getImageUrl)
                 .findFirst()
                 .orElse(null);
 
+        ArchiveType type = archive.getType();
+
         return new SimpleArchiveInfo(
-                archive.getId(), archive.getTitle(), archive.getType(), thumbnail
+                archive.getId(), archive.getTitle(),
+                !type.equals(ArchiveType.NO_COLOR) ? type.toString() : "DEFAULT",
+                imageUrl,
+                archive.getDescription(), archive.getIntroduction(),
+                archive.isCanComment(), archive.getCreateAt().toString()
         );
     }
 }

--- a/src/main/java/com/palettee/user/controller/dto/response/users/SimpleGatheringInfo.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/SimpleGatheringInfo.java
@@ -1,23 +1,32 @@
 package com.palettee.user.controller.dto.response.users;
 
 import com.palettee.gathering.domain.*;
+import com.palettee.gathering.repository.*;
+import java.util.*;
 
 public record SimpleGatheringInfo(
         Long gatheringId,
         String title,
-        String thumbnailImageUrl
+
+        String sort,
+        int person,
+        String subject,
+        String deadLine,
+        List<String> tags
 ) {
 
-    public static SimpleGatheringInfo of(Gathering gathering) {
-
-        String thumbnailImage = gathering.getGatheringImages()
-                .stream()
-                .map(GatheringImage::getImageUrl)
-                .findFirst()
-                .orElse(null);
+    public static SimpleGatheringInfo of(Gathering gathering,
+            GatheringTagRepository gatheringTagRepo) {
+        Long id = gathering.getId();
+        List<String> tags = gatheringTagRepo.findByGatheringId(id)
+                .stream().map(GatheringTag::getContent)
+                .toList();
 
         return new SimpleGatheringInfo(
-                gathering.getId(), gathering.getTitle(), thumbnailImage
+                id, gathering.getTitle(),
+                gathering.getSort().toString(), gathering.getPersonnel(),
+                gathering.getSubject().toString(), gathering.getDeadLine().toString(),
+                tags
         );
     }
 }

--- a/src/main/java/com/palettee/user/service/UserService.java
+++ b/src/main/java/com/palettee/user/service/UserService.java
@@ -31,6 +31,7 @@ public class UserService {
     private final StoredProfileImageUrlRepository storedProfileImageUrlRepo;
     private final ArchiveRepository archiveRepo;
     private final GatheringRepository gatheringRepo;
+    private final GatheringTagRepository gatheringTagRepo;
     private final RefreshTokenRedisService refreshTokenRedisService;
 
     /**
@@ -219,9 +220,11 @@ public class UserService {
     public GetUserGatheringResponse getUserGatherings(
             Long userId, int size, Long prevGatheringId
     ) {
-        return gatheringRepo.findGatheringsOnUserWithNoOffset(
+        GatheringPagingDTO pagingDTO = gatheringRepo.findGatheringsOnUserWithNoOffset(
                 userId, size, prevGatheringId
         );
+
+        return GetUserGatheringResponse.of(pagingDTO, gatheringTagRepo);
     }
 
 

--- a/src/main/java/com/palettee/user/service/UserService.java
+++ b/src/main/java/com/palettee/user/service/UserService.java
@@ -196,6 +196,19 @@ public class UserService {
     }
 
     /**
+     * 유저가 작성한 아카이브들의 색상 통계를 보여주는 메서드
+     *
+     * @param userId 아카이브 색상 통계 조회할 유저 id
+     */
+    public GetArchiveColorStatisticsResponse getArchiveColorStatistics(
+            Long userId
+    ) {
+        return GetArchiveColorStatisticsResponse.of(
+                archiveRepo.findAllByUserId(userId)
+        );
+    }
+
+    /**
      * 유저가 작성한 아카이브 목록 보여주는 메서드
      *
      * @param userId        아카이브 조회할 유저 id

--- a/src/main/resources/logback-appender.xml
+++ b/src/main/resources/logback-appender.xml
@@ -55,7 +55,7 @@
   <!-- 에러난 부분만 편하게 볼 수 있도록 집계하는 appender -->
   <appender name="EXCEPTION" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${LOG_DIR}/exceptions/%d{yyyy-MM-dd}-%02i.log</fileNamePattern>
+      <fileNamePattern>${LOG_DIR}/exceptions/exceptions.%d{yyyy-MM-dd}-%02i.log</fileNamePattern>
       <maxFileSize>5MB</maxFileSize>
       <maxHistory>21</maxHistory>
       <cleanHistoryOnStart>true</cleanHistoryOnStart>


### PR DESCRIPTION
## #️⃣연관된 이슈

Close: #115 

## 📝작업 내용

- 유저가 소유한 아카이브 목록 조회시 응답 데이터 추가 `(GET - /user/{userId}/archives)`
- 유저가 작성한 게더링 목록 조회시 응답 데이터 추가 `(GET - /user/{userId}/gatherings)`
- 유저가 작성한 모든 아카이브의 색상 통계를 보여주는 API 추가 `(GET - /user/{userId}/archive-colors)`

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
