### PR TITLE
#131 - 이미지 변경 추적 기능 추가

### DIFF
--- a/src/main/java/com/palettee/PaletteApplication.java
+++ b/src/main/java/com/palettee/PaletteApplication.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableScheduling
 @EnableCaching
+@EnableAsync
 public class PaletteApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/palettee/archive/controller/ArchiveController.java
+++ b/src/main/java/com/palettee/archive/controller/ArchiveController.java
@@ -39,13 +39,17 @@ public class ArchiveController {
     private final CommentService commentService;
 
     @PostMapping
-    public ArchiveResponse registerArchive(@Valid @RequestBody ArchiveRegisterRequest archiveRegisterRequest) {
+    public ArchiveResponse registerArchive(
+            @Valid @RequestBody ArchiveRegisterRequest archiveRegisterRequest
+    ) {
         User user = UserUtils.getContextUser();
         return archiveService.registerArchive(archiveRegisterRequest, user);
     }
 
     @GetMapping("/{archiveId}")
-    public ArchiveDetailResponse getArchive(@PathVariable("archiveId") long archiveId) {
+    public ArchiveDetailResponse getArchive(
+            @PathVariable("archiveId") Long archiveId
+    ) {
         return archiveService.getArchiveDetail(archiveId, getContextUser());
     }
 
@@ -92,27 +96,39 @@ public class ArchiveController {
     }
 
     @PutMapping("/{archiveId}")
-    public ArchiveResponse updateArchive(@PathVariable("archiveId") long archiveId, @Valid @RequestBody ArchiveUpdateRequest archiveUpdateRequest) {
+    public ArchiveResponse updateArchive(
+            @PathVariable("archiveId") Long archiveId,
+            @Valid @RequestBody ArchiveUpdateRequest archiveUpdateRequest
+    ) {
         return archiveService.updateArchive(archiveId, archiveUpdateRequest, UserUtils.getContextUser());
     }
 
     @DeleteMapping("/{archiveId}")
-    public ArchiveResponse deleteArchive(@PathVariable("archiveId") long archiveId) {
+    public ArchiveResponse deleteArchive(
+            @PathVariable("archiveId") Long archiveId
+    ) {
         return archiveService.deleteArchive(archiveId, UserUtils.getContextUser());
     }
 
     @PatchMapping
-    public void updateOrder(@Valid @RequestBody ChangeOrderRequest changeOrderRequest) {
+    public void updateOrder(
+            @Valid @RequestBody ChangeOrderRequest changeOrderRequest
+    ) {
         archiveService.changeArchiveOrder(changeOrderRequest, UserUtils.getContextUser());
     }
 
     @PostMapping("/{archiveId}")
-    public ArchiveResponse likeArchive(@PathVariable("archiveId") Long archiveId) {
+    public ArchiveResponse likeArchive(
+            @PathVariable("archiveId") Long archiveId
+    ) {
         return archiveService.likeArchive(archiveId, UserUtils.getContextUser());
     }
 
     @PostMapping("/{archiveId}/comment")
-    public CommentResponse writeComment(@PathVariable("archiveId") long archiveId, @Valid @RequestBody CommentWriteRequest commentWriteRequest) {
+    public CommentResponse writeComment(
+            @PathVariable("archiveId") Long archiveId,
+            @Valid @RequestBody CommentWriteRequest commentWriteRequest
+    ) {
         User user = UserUtils.getContextUser();
         return commentService.writeComment(user, archiveId, commentWriteRequest);
     }
@@ -129,13 +145,18 @@ public class ArchiveController {
     }
 
     @PutMapping("/comment/{commentId}")
-    public CommentResponse updateComment(@PathVariable("commentId") long commentId, @Valid @RequestBody CommentUpdateRequest commentUpdateRequest) {
+    public CommentResponse updateComment(
+            @PathVariable("commentId") Long commentId,
+            @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
+    ) {
         User user = UserUtils.getContextUser();
         return commentService.updateComment(user, commentId, commentUpdateRequest);
     }
 
     @DeleteMapping("/comment/{commentId}")
-    public CommentResponse deleteComment(@PathVariable("commentId") long commentId) {
+    public CommentResponse deleteComment(
+            @PathVariable("commentId") Long commentId
+    ) {
         User user = UserUtils.getContextUser();
         return commentService.deleteComment(commentId, user.getId());
     }

--- a/src/main/java/com/palettee/archive/controller/dto/response/ArchiveRedisResponse.java
+++ b/src/main/java/com/palettee/archive/controller/dto/response/ArchiveRedisResponse.java
@@ -17,9 +17,7 @@ public record ArchiveRedisResponse(
         String createDate
 ) implements Serializable {
 
-    public static ArchiveRedisResponse toResponse(Archive archive) {
-        String imageUrl = archive.getArchiveImages().isEmpty() ? "" : archive.getArchiveImages().get(0).getImageUrl();
-
+    public static ArchiveRedisResponse toResponse(Archive archive, String thumbnail) {
         return new ArchiveRedisResponse(
                 archive.getId(),
                 archive.getTitle(),
@@ -30,7 +28,7 @@ public record ArchiveRedisResponse(
                 archive.isCanComment(),
                 archive.getLikeCount(),
                 false,
-                imageUrl,
+                thumbnail,
                 archive.getCreateAt().toLocalDate().toString()
         );
     }

--- a/src/main/java/com/palettee/archive/controller/dto/response/ArchiveSimpleResponse.java
+++ b/src/main/java/com/palettee/archive/controller/dto/response/ArchiveSimpleResponse.java
@@ -18,9 +18,7 @@ public record ArchiveSimpleResponse(
         String createDate
 ) implements Serializable {
 
-    public static ArchiveSimpleResponse toResponse(Archive archive, Long userId, LikeRepository likeRepository) {
-        String imageUrl = archive.getArchiveImages().isEmpty() ? "" : archive.getArchiveImages().get(0).getImageUrl();
-
+    public static ArchiveSimpleResponse toResponse(Archive archive, Long userId, LikeRepository likeRepository, String thumbnail) {
         return new ArchiveSimpleResponse(
                 archive.getId(),
                 archive.getTitle(),
@@ -31,7 +29,7 @@ public record ArchiveSimpleResponse(
                 archive.isCanComment(),
                 archive.getLikeCount(),
                 likeRepository.existByUserAndArchive(archive.getId(), userId).isPresent(),
-                imageUrl,
+                thumbnail,
                 archive.getCreateAt().toLocalDate().toString()
         );
     }

--- a/src/main/java/com/palettee/archive/domain/Archive.java
+++ b/src/main/java/com/palettee/archive/domain/Archive.java
@@ -41,9 +41,6 @@ public class Archive extends BaseEntity {
     private List<Tag> tags = new ArrayList<>();
 
     @OneToMany(mappedBy = "archive", cascade = CascadeType.REMOVE)
-    private List<ArchiveImage> archiveImages = new ArrayList<>();
-
-    @OneToMany(mappedBy = "archive", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
@@ -64,10 +61,6 @@ public class Archive extends BaseEntity {
 
     public void addTag(Tag tag) {
         this.tags.add(tag);
-    }
-
-    public void addProjectImage(ArchiveImage archiveImage) {
-        this.archiveImages.add(archiveImage);
     }
 
     public void addComment(Comment comment) {

--- a/src/main/java/com/palettee/archive/domain/ArchiveImage.java
+++ b/src/main/java/com/palettee/archive/domain/ArchiveImage.java
@@ -14,14 +14,11 @@ public class ArchiveImage {
 
     private String imageUrl;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "archive_id")
-    private Archive archive;
+    private Long archiveId;
 
     @Builder
-    public ArchiveImage(String imageUrl, Archive archive) {
+    public ArchiveImage(String imageUrl, Long archiveId) {
         this.imageUrl = imageUrl;
-        this.archive = archive;
-        archive.addProjectImage(this);
+        this.archiveId = archiveId;
     }
 }

--- a/src/main/java/com/palettee/archive/event/HitEventListener.java
+++ b/src/main/java/com/palettee/archive/event/HitEventListener.java
@@ -13,24 +13,40 @@ public class HitEventListener {
 
     private static final String SET_KEY_PREFIX = "hit:archiveId:";
     private static final String VALUE_KEY_PREFIX = "incr:hit:archiveId:";
+    private static final Duration EXPIRE_DURATION = Duration.ofDays(1);
 
     private final RedisTemplate<String, String> redisTemplate;
 
     @Async
     @EventListener(value = HitEvent.class)
-    public void onHit(HitEvent event) {
+    public void handleHitEvent(HitEvent event) {
+        if (isUniqueHit(event)) {
+            incrementHitCount(event.archiveId());
+        }
+    }
 
-        String setKey = SET_KEY_PREFIX + event.archiveId();
+    private boolean isUniqueHit(HitEvent event) {
+        String setKey = generateSetKey(event.archiveId());
         Long addResult = redisTemplate.opsForSet().add(setKey, event.email());
 
-        if (addResult == null || addResult != 1L) {
-            return;
+        if (addResult != null && addResult == 1L) {
+            redisTemplate.expire(setKey, EXPIRE_DURATION);
+            return true;
         }
+        return false;
+    }
 
-        redisTemplate.expire(setKey, Duration.ofDays(1));
-
-        String valueKey = VALUE_KEY_PREFIX + event.archiveId();
+    private void incrementHitCount(Long archiveId) {
+        String valueKey = generateValueKey(archiveId);
         redisTemplate.opsForValue().increment(valueKey);
+    }
+
+    private String generateSetKey(Long archiveId) {
+        return SET_KEY_PREFIX + archiveId;
+    }
+
+    private String generateValueKey(Long archiveId) {
+        return VALUE_KEY_PREFIX + archiveId;
     }
 
 }

--- a/src/main/java/com/palettee/archive/repository/ArchiveCustomRepositoryImpl.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveCustomRepositoryImpl.java
@@ -16,9 +16,11 @@ import org.springframework.stereotype.*;
 public class ArchiveCustomRepositoryImpl implements ArchiveCustomRepository{
 
     private final JPAQueryFactory queryFactory;
+    private final ArchiveImageRepository archiveImageRepository;
 
-    public ArchiveCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+    public ArchiveCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory, ArchiveImageRepository archiveImageRepository) {
         this.queryFactory = jpaQueryFactory;
+        this.archiveImageRepository = archiveImageRepository;
     }
 
     @Override
@@ -101,7 +103,7 @@ public class ArchiveCustomRepositoryImpl implements ArchiveCustomRepository{
         }
 
         return GetUserArchiveResponse.of(
-                searchResult, hasNext, nextOffset
+                searchResult, hasNext, nextOffset, archiveImageRepository
         );
     }
 

--- a/src/main/java/com/palettee/archive/repository/ArchiveImageRepository.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveImageRepository.java
@@ -15,8 +15,11 @@ public interface ArchiveImageRepository extends JpaRepository<ArchiveImage, Long
     void deleteAllByArchiveId(@Param("archiveId") Long archiveId);
 
     @Modifying(flushAutomatically = true)
-    void deleteByArchive(Archive archive);
+    void deleteByArchiveId(Long archiveId);
 
     @Query("select ai.imageUrl from ArchiveImage ai where ai.archiveId = :archiveId")
-    List<String> findAllByArchiveId(Long archivedId);
+    List<String> findAllByArchiveId(Long archiveId);
+
+    @Query("select ai.imageUrl from ArchiveImage ai where ai.archiveId = :archiveId order by ai.id limit 1")
+    String getArchiveThumbnail(Long archiveId);
 }

--- a/src/main/java/com/palettee/archive/repository/ArchiveImageRepository.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveImageRepository.java
@@ -7,13 +7,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface ArchiveImageRepository extends JpaRepository<ArchiveImage, Long> {
 
-    @Query("select ai.imageUrl from ArchiveImage ai where ai.archive.id = :archiveId")
+    @Query("select ai.imageUrl from ArchiveImage ai where ai.archiveId = :archiveId")
     List<String> findByArchiveId(@Param("archiveId") Long archiveId);
 
     @Modifying(flushAutomatically = true)
-    @Query("delete from ArchiveImage ai where ai.archive.id = :archiveId")
+    @Query("delete from ArchiveImage ai where ai.archiveId = :archiveId")
     void deleteAllByArchiveId(@Param("archiveId") Long archiveId);
 
     @Modifying(flushAutomatically = true)
     void deleteByArchive(Archive archive);
+
+    @Query("select ai.imageUrl from ArchiveImage ai where ai.archiveId = :archiveId")
+    List<String> findAllByArchiveId(Long archivedId);
 }

--- a/src/main/java/com/palettee/archive/repository/ArchiveRedisRepository.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveRedisRepository.java
@@ -32,6 +32,7 @@ public class ArchiveRedisRepository {
     private final RedisTemplate<String, Object> redisTemplateForArchive;
 
     private final ArchiveRepository archiveRepository;
+    private final ArchiveImageRepository archiveImageRepository;
 
     @Transactional
     public void settleHits() {
@@ -81,7 +82,7 @@ public class ArchiveRedisRepository {
         }
 
         List<ArchiveRedisResponse> redis = result.stream()
-                        .map(ArchiveRedisResponse::toResponse)
+                        .map(it -> ArchiveRedisResponse.toResponse(it, archiveImageRepository.getArchiveThumbnail(it.getId())))
                         .toList();
         log.info("Redis에 저장될 데이터: {}", redis);
         redisTemplateForArchive.opsForValue().set(TOP_ARCHIVE, new ArchiveRedisList(redis), 1, TimeUnit.HOURS);

--- a/src/main/java/com/palettee/archive/repository/ArchiveRedisRepository.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveRedisRepository.java
@@ -13,20 +13,13 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-@Slf4j
 @RequiredArgsConstructor
 public class ArchiveRedisRepository {
-
-    private static final String INCR_PATTERN = "incr:hit:archiveId:*";
-    private static final String STD_PATTERN = "std:hit:archiveId:";
-    private static final String TOP_ARCHIVE = "top_archives";
-    private static final String DELIMITER = ":";
 
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisTemplate<String, Object> redisTemplateForArchive;
@@ -34,9 +27,16 @@ public class ArchiveRedisRepository {
     private final ArchiveRepository archiveRepository;
     private final ArchiveImageRepository archiveImageRepository;
 
+    private static final String INCR_KEY_PREFIX = "incr:hit:archiveId:";
+    private static final String STD_KEY_PREFIX = "std:hit:archiveId:";
+    private static final String LIKE_KEY_PREFIX = "like:archiveId:";
+    private static final String TOP_ARCHIVE_KEY = "top_archives";
+    private static final String DELIMITER = ":";
+    private static final long TOP_ARCHIVE_TTL = 1; // TTL in hours
+
     @Transactional
     public void settleHits() {
-        Set<String> incrKeys = redisTemplate.keys(INCR_PATTERN);
+        Set<String> incrKeys = redisTemplate.keys(INCR_KEY_PREFIX + "*");
         if (incrKeys == null || incrKeys.isEmpty()) {
             return;
         }
@@ -47,7 +47,7 @@ public class ArchiveRedisRepository {
             String incrHits = redisTemplate.opsForValue().get(incrKey);
             long incrCount = incrHits == null ? 0 : Long.parseLong(incrHits);
 
-            String stdKey = STD_PATTERN + archiveId;
+            String stdKey = STD_KEY_PREFIX + archiveId;
             String stdHits = redisTemplate.opsForValue().get(stdKey);
             long stdCount = stdHits == null ? 0 : Long.parseLong(stdHits);
 
@@ -65,55 +65,50 @@ public class ArchiveRedisRepository {
         archive.setHit(totalHits);
     }
 
-    private String extractId(String incrKey) {
-        return incrKey.split(DELIMITER)[3];
+    private String extractId(String key) {
+        return key.split(DELIMITER)[3];
     }
 
     @Transactional(readOnly = true)
     public void updateArchiveList() {
-        List<Long> top4IncrKeys = getTop4IncrKeys();
-        List<Archive> result = archiveRepository.findArchivesInIds(top4IncrKeys);
+        List<Long> top4ArchiveIds = getTop4ArchiveIds();
+        List<Archive> archives = archiveRepository.findArchivesInIds(top4ArchiveIds);
 
-        int redisSize = result.size();
+        int redisSize = archives.size();
         if (redisSize < 4) {
             int remaining = 4 - redisSize;
             List<Archive> additionalFromDB = archiveRepository.findTopArchives(remaining);
-            result.addAll(additionalFromDB);
+            archives.addAll(additionalFromDB);
         }
 
-        List<ArchiveRedisResponse> redis = result.stream()
-                        .map(it -> ArchiveRedisResponse.toResponse(it, archiveImageRepository.getArchiveThumbnail(it.getId())))
-                        .toList();
-        log.info("Redis에 저장될 데이터: {}", redis);
-        redisTemplateForArchive.opsForValue().set(TOP_ARCHIVE, new ArchiveRedisList(redis), 1, TimeUnit.HOURS);
+        List<ArchiveRedisResponse> redisData = archives.stream()
+                .map(archive -> ArchiveRedisResponse.toResponse(
+                        archive, archiveImageRepository.getArchiveThumbnail(archive.getId())))
+                .toList();
+
+        redisTemplateForArchive.opsForValue().set(TOP_ARCHIVE_KEY, new ArchiveRedisList(redisData), TOP_ARCHIVE_TTL, TimeUnit.HOURS);
     }
 
-    private List<Long> getTop4IncrKeys() {
-        String hitPattern = "incr:hit:archiveId:*";
-        String likePattern = "like:archiveId:*";
-
-        // Redis에서 키 가져오기
-        Set<String> hitKeys = redisTemplate.keys(hitPattern);
-        Set<String> likeKeys = redisTemplate.keys(likePattern);
+    private List<Long> getTop4ArchiveIds() {
+        Set<String> hitKeys = redisTemplate.keys(INCR_KEY_PREFIX + "*");
+        Set<String> likeKeys = redisTemplate.keys(LIKE_KEY_PREFIX + "*");
 
         if (hitKeys == null || likeKeys == null) {
             return Collections.emptyList();
         }
 
-        // 점수 계산
         Map<Long, Integer> archiveScores = new HashMap<>();
         for (String hitKey : hitKeys) {
             Long archiveId = extractArchiveId(hitKey);
-            Integer hitCount = getValueAsInt(hitKey);
+            int hitCount = getValueAsInt(hitKey);
 
-            String likeKey = "like:archiveId:" + archiveId;
-            Integer likeCount = getValueAsInt(likeKey);
+            String likeKey = LIKE_KEY_PREFIX + archiveId;
+            int likeCount = getValueAsInt(likeKey);
 
             int score = hitCount + (likeCount * 5);
             archiveScores.put(archiveId, score);
         }
 
-        // 정렬 및 상위 4개 추출
         return archiveScores.entrySet().stream()
                 .sorted(Map.Entry.<Long, Integer>comparingByValue().reversed())
                 .limit(4)
@@ -122,21 +117,20 @@ public class ArchiveRedisRepository {
     }
 
     private Long extractArchiveId(String key) {
-        return Long.valueOf(key.replace("incr:hit:archiveId:", ""));
+        return Long.valueOf(key.replace(INCR_KEY_PREFIX, ""));
     }
 
-    private Integer getValueAsInt(String key) {
+    private int getValueAsInt(String key) {
         String value = redisTemplate.opsForValue().get(key);
         return value != null ? Integer.parseInt(value) : 0;
     }
 
     public ArchiveRedisList getTopArchives() {
         try {
-            ArchiveRedisList result = (ArchiveRedisList) redisTemplateForArchive.opsForValue().get(TOP_ARCHIVE);
+            ArchiveRedisList result = (ArchiveRedisList) redisTemplateForArchive.opsForValue().get(TOP_ARCHIVE_KEY);
             return result == null ? new ArchiveRedisList(new ArrayList<>()) : result;
         } catch (SerializationException e) {
-            log.error("Redis 역직렬화 실패: {}", e.getMessage());
-            redisTemplateForArchive.delete(TOP_ARCHIVE);
+            redisTemplateForArchive.delete(TOP_ARCHIVE_KEY);
             return new ArchiveRedisList(new ArrayList<>());
         }
     }

--- a/src/main/java/com/palettee/archive/repository/ArchiveRepository.java
+++ b/src/main/java/com/palettee/archive/repository/ArchiveRepository.java
@@ -27,10 +27,6 @@ public interface ArchiveRepository extends JpaRepository<Archive, Long>, Archive
     @Query("SELECT a FROM Archive a where a.user.id = :userId")
     List<Archive> findAllByUserId(Long userId);
 
-    @Modifying
-    @Query("UPDATE Archive a SET a.hits = :hitCount WHERE a.id = :archiveId")
-    void updateHitCount(@Param("archiveId") Long archiveId, @Param("hitCount") Long hitCount);
-
     @Query("select a from Archive a order by (a.hits + a.likeCount * 5) desc, a.id desc limit :limit")
     List<Archive> findTopArchives(@Param("limit") int limit);
 

--- a/src/main/java/com/palettee/archive/service/ArchiveScheduler.java
+++ b/src/main/java/com/palettee/archive/service/ArchiveScheduler.java
@@ -11,7 +11,7 @@ public class ArchiveScheduler {
 
     private final ArchiveRedisRepository archiveRedisRepository;
 
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 * * * *")
     public void updateMainArchive() {
         archiveRedisRepository.updateArchiveList();
         archiveRedisRepository.settleHits();

--- a/src/main/java/com/palettee/archive/service/ArchiveService.java
+++ b/src/main/java/com/palettee/archive/service/ArchiveService.java
@@ -55,7 +55,6 @@ public class ArchiveService {
         archive.setOrder();
         processingTags(archiveRegisterRequest.tags(), archive);
         publisher.publishEvent(new ImageProcessingEvent(archive.getDescription(), archive.getId(), ContentType.ARCHIVE));
-//        processingImage(archiveRegisterRequest.imageUrls(), archive);
 
         // 아카이브 등록시 유저 권한 상승
         findUser.changeUserRole(UserRole.USER);
@@ -152,7 +151,6 @@ public class ArchiveService {
         deleteAllInfo(archiveId);
         processingTags(archiveUpdateRequest.tags(), archive);
         publisher.publishEvent(new ImageProcessingEvent(archiveUpdateRequest.description(), archive.getId(), ContentType.ARCHIVE));
-//        processingImage(archiveUpdateRequest.imageUrls(), archive);
 
         return new ArchiveResponse(updatedArchive.getId());
     }

--- a/src/main/java/com/palettee/archive/service/ArchiveService.java
+++ b/src/main/java/com/palettee/archive/service/ArchiveService.java
@@ -7,6 +7,8 @@ import com.palettee.archive.event.HitEvent;
 import com.palettee.archive.event.LikeEvent;
 import com.palettee.archive.exception.*;
 import com.palettee.archive.repository.*;
+import com.palettee.image.ContentType;
+import com.palettee.image.event.ImageProcessingEvent;
 import com.palettee.likes.domain.LikeType;
 import com.palettee.likes.domain.Likes;
 import com.palettee.likes.repository.*;
@@ -52,7 +54,8 @@ public class ArchiveService {
         Archive savedArchive = archiveRepository.save(archive);
         archive.setOrder();
         processingTags(archiveRegisterRequest.tags(), archive);
-        processingImage(archiveRegisterRequest.imageUrls(), archive);
+        publisher.publishEvent(new ImageProcessingEvent(archive.getDescription(), archive.getId(), ContentType.ARCHIVE));
+//        processingImage(archiveRegisterRequest.imageUrls(), archive);
 
         // 아카이브 등록시 유저 권한 상승
         findUser.changeUserRole(UserRole.USER);

--- a/src/main/java/com/palettee/archive/service/ArchiveService.java
+++ b/src/main/java/com/palettee/archive/service/ArchiveService.java
@@ -79,7 +79,7 @@ public class ArchiveService {
     }
 
     public ArchiveListResponse getMainArchive(User contextUser) {
-        Long userId = contextUser == null ? 0L : contextUser.getId();
+        Long userId = getOptionalUserId(contextUser);
         List<ArchiveSimpleResponse> result = archiveRedisRepository.getTopArchives().archives()
                 .stream()
                 .map(it -> ArchiveSimpleResponse.changeToSimpleResponse(it, userId, likeRepository))
@@ -90,7 +90,7 @@ public class ArchiveService {
     @Transactional
     public ArchiveDetailResponse getArchiveDetail(Long archiveId, User user) {
         Archive archive = getArchive(archiveId);
-        Long userId = user == null ? 0L : user.getId();
+        Long userId = getOptionalUserId(user);
         String email = user == null ? "" : user.getEmail();
         publisher.publishEvent(new HitEvent(archiveId, email));
         return ArchiveDetailResponse.toResponse(

--- a/src/main/java/com/palettee/archive/service/ArchiveService.java
+++ b/src/main/java/com/palettee/archive/service/ArchiveService.java
@@ -151,7 +151,8 @@ public class ArchiveService {
 
         deleteAllInfo(archiveId);
         processingTags(archiveUpdateRequest.tags(), archive);
-        processingImage(archiveUpdateRequest.imageUrls(), archive);
+        publisher.publishEvent(new ImageProcessingEvent(archiveUpdateRequest.description(), archive.getId(), ContentType.ARCHIVE));
+//        processingImage(archiveUpdateRequest.imageUrls(), archive);
 
         return new ArchiveResponse(updatedArchive.getId());
     }
@@ -216,12 +217,6 @@ public class ArchiveService {
     private void processingTags(List<TagDto> tags, Archive archive) {
         for (TagDto dto : tags) {
             tagRepository.save(new Tag(dto.tag(), archive));
-        }
-    }
-
-    private void processingImage(List<ImageUrlDto> imageUrls, Archive archive) {
-        for (ImageUrlDto dto : imageUrls) {
-            archiveImageRepository.save(new ArchiveImage(dto.url(), archive));
         }
     }
 

--- a/src/main/java/com/palettee/archive/service/ArchiveService.java
+++ b/src/main/java/com/palettee/archive/service/ArchiveService.java
@@ -69,7 +69,7 @@ public class ArchiveService {
         Long myId = getOptionalUserId(optionalUser);
 
         List<ArchiveSimpleResponse> list = archives
-                .map(it -> ArchiveSimpleResponse.toResponse(it, myId, likeRepository))
+                .map(it -> ArchiveSimpleResponse.toResponse(it, myId, likeRepository, getArchiveThumbnail(it.getId())))
                 .toList();
 
         return new ArchiveListResponse(list, colorCounts, SliceInfo.of(archives));
@@ -113,7 +113,7 @@ public class ArchiveService {
 
         List<ArchiveSimpleResponse> result = archives
                 .stream()
-                .map(it -> ArchiveSimpleResponse.toResponse(it, user.getId(), likeRepository))
+                .map(it -> ArchiveSimpleResponse.toResponse(it, user.getId(), likeRepository, getArchiveThumbnail(it.getId())))
                 .toList();
         List<ColorCount> colorCounts = archiveRepository.countMyArchiveByArchiveType(user.getId());
         return new ArchiveListResponse(result, colorCounts, SliceInfo.of(archives));
@@ -125,7 +125,7 @@ public class ArchiveService {
         Slice<Archive> archives = archiveRepository.findAllInIds(ids, pageable);
         List<ArchiveSimpleResponse> result = archives
                 .stream()
-                .map(it -> ArchiveSimpleResponse.toResponse(it, user.getId(), likeRepository))
+                .map(it -> ArchiveSimpleResponse.toResponse(it, user.getId(), likeRepository, getArchiveThumbnail(it.getId())))
                 .toList();
         return new ArchiveListResponse(result, colorCounts, SliceInfo.of(archives));
     }
@@ -136,7 +136,7 @@ public class ArchiveService {
         Slice<Archive> archives = archiveRepository.searchArchive(searchKeyword, ids, pageable);
 
         List<ArchiveSimpleResponse> list = archives
-                .map(it -> ArchiveSimpleResponse.toResponse(it, myId, likeRepository))
+                .map(it -> ArchiveSimpleResponse.toResponse(it, myId, likeRepository, getArchiveThumbnail(it.getId())))
                 .toList();
 
         return new ArchiveListResponse(list, null, SliceInfo.of(archives));
@@ -164,7 +164,7 @@ public class ArchiveService {
         checkArchiveOwner(user, archive);
 
         tagRepository.deleteByArchive(archive);
-        archiveImageRepository.deleteByArchive(archive);
+        archiveImageRepository.deleteByArchiveId(archiveId);
         archiveRepository.delete(archive);
         return new ArchiveResponse(archiveId);
     }
@@ -227,6 +227,10 @@ public class ArchiveService {
     private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
+
+    private String getArchiveThumbnail(Long archiveId) {
+        return archiveImageRepository.getArchiveThumbnail(archiveId);
     }
 
 }

--- a/src/main/java/com/palettee/image/ContentType.java
+++ b/src/main/java/com/palettee/image/ContentType.java
@@ -1,13 +1,7 @@
 package com.palettee.image;
 
 public enum ContentType {
-    PORTFOLIO("portFolio"),
-    ARCHIVE("archive"),
-    GATHERING("gathering");
-
-    private final String code;
-
-    ContentType(String code) {
-        this.code = code;
-    }
+    PORTFOLIO,
+    ARCHIVE,
+    GATHERING
 }

--- a/src/main/java/com/palettee/image/ContentType.java
+++ b/src/main/java/com/palettee/image/ContentType.java
@@ -1,0 +1,13 @@
+package com.palettee.image;
+
+public enum ContentType {
+    PORTFOLIO("portFolio"),
+    ARCHIVE("archive"),
+    GATHERING("gathering");
+
+    private final String code;
+
+    ContentType(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/java/com/palettee/image/ImageProcessor.java
+++ b/src/main/java/com/palettee/image/ImageProcessor.java
@@ -1,0 +1,7 @@
+package com.palettee.image;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageProcessor {
+}

--- a/src/main/java/com/palettee/image/ImageProcessor.java
+++ b/src/main/java/com/palettee/image/ImageProcessor.java
@@ -11,13 +11,16 @@ public class ImageProcessor {
 
     Pattern pattern = Pattern.compile("!\\[.*?]\\((https?://[^)]+)\\)");
 
+    /**
+     *  본문에서 이미지 태그를 추출해서 이미지 링크를 전부 가져옵니다.
+     * @param content
+     * @return List
+     */
     public List<String> parseImageTag(String content) {
         Matcher matcher = pattern.matcher(content);
 
-        // URL 저장 리스트
         List<String> imageUrls = new ArrayList<>();
         while (matcher.find()) {
-            // 캡처 그룹에서 URL 추출
             imageUrls.add(matcher.group(1));
         }
         return imageUrls;

--- a/src/main/java/com/palettee/image/ImageProcessor.java
+++ b/src/main/java/com/palettee/image/ImageProcessor.java
@@ -1,7 +1,25 @@
 package com.palettee.image;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ImageProcessor {
+
+    Pattern pattern = Pattern.compile("!\\[.*?]\\((https?://[^)]+)\\)");
+
+    public List<String> parseImageTag(String content) {
+        Matcher matcher = pattern.matcher(content);
+
+        // URL 저장 리스트
+        List<String> imageUrls = new ArrayList<>();
+        while (matcher.find()) {
+            // 캡처 그룹에서 URL 추출
+            imageUrls.add(matcher.group(1));
+        }
+        return imageUrls;
+    }
 }

--- a/src/main/java/com/palettee/image/event/ImageEventListener.java
+++ b/src/main/java/com/palettee/image/event/ImageEventListener.java
@@ -2,10 +2,12 @@ package com.palettee.image.event;
 
 import com.palettee.archive.domain.ArchiveImage;
 import com.palettee.archive.repository.ArchiveImageRepository;
+import com.palettee.global.s3.service.ImageService;
 import com.palettee.image.ImageProcessor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,15 +17,30 @@ public class ImageEventListener {
 
     private final ArchiveImageRepository archiveImageRepository;
     private final ImageProcessor imageProcessor;
+    private final ImageService imageService;
 
+    @Async
     @Transactional
     @EventListener(ImageProcessingEvent.class)
     public void process(ImageProcessingEvent event) {
         List<String> imageUrls = imageProcessor.parseImageTag(event.content());
         Long archiveId = event.targetId();
+
+        deleteImages(archiveId);
+
         for (String imageUrl : imageUrls) {
             archiveImageRepository.save(new ArchiveImage(imageUrl, archiveId));
         }
+    }
+
+    private void deleteImages(Long archivedId) {
+        List<String> OldImageUrls = archiveImageRepository.findAllByArchiveId(archivedId);
+
+        for (String oldImageUrl : OldImageUrls) {
+            imageService.delete(oldImageUrl);
+        }
+
+        archiveImageRepository.deleteAllByArchiveId(archivedId);
     }
 
 }

--- a/src/main/java/com/palettee/image/event/ImageEventListener.java
+++ b/src/main/java/com/palettee/image/event/ImageEventListener.java
@@ -1,21 +1,29 @@
 package com.palettee.image.event;
 
+import com.palettee.archive.domain.ArchiveImage;
+import com.palettee.archive.repository.ArchiveImageRepository;
 import com.palettee.image.ImageProcessor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class ImageEventListener {
 
+    private final ArchiveImageRepository archiveImageRepository;
     private final ImageProcessor imageProcessor;
 
+    @Transactional
     @EventListener(ImageProcessingEvent.class)
     public void process(ImageProcessingEvent event) {
         List<String> imageUrls = imageProcessor.parseImageTag(event.content());
-
+        Long archiveId = event.targetId();
+        for (String imageUrl : imageUrls) {
+            archiveImageRepository.save(new ArchiveImage(imageUrl, archiveId));
+        }
     }
 
 }

--- a/src/main/java/com/palettee/image/event/ImageEventListener.java
+++ b/src/main/java/com/palettee/image/event/ImageEventListener.java
@@ -1,0 +1,19 @@
+package com.palettee.image.event;
+
+import com.palettee.image.ImageProcessor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+
+    private final ImageProcessor imageProcessor;
+
+    @EventListener(ImageProcessingEvent.class)
+    public void process(ImageProcessingEvent event) {
+
+    }
+
+}

--- a/src/main/java/com/palettee/image/event/ImageEventListener.java
+++ b/src/main/java/com/palettee/image/event/ImageEventListener.java
@@ -1,6 +1,7 @@
 package com.palettee.image.event;
 
 import com.palettee.image.ImageProcessor;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ public class ImageEventListener {
 
     @EventListener(ImageProcessingEvent.class)
     public void process(ImageProcessingEvent event) {
+        List<String> imageUrls = imageProcessor.parseImageTag(event.content());
 
     }
 

--- a/src/main/java/com/palettee/image/event/ImageProcessingEvent.java
+++ b/src/main/java/com/palettee/image/event/ImageProcessingEvent.java
@@ -1,0 +1,10 @@
+package com.palettee.image.event;
+
+import com.palettee.image.ContentType;
+
+public record ImageProcessingEvent(
+        String content,
+        Long targetId,
+        ContentType contentType
+) {
+}

--- a/src/main/java/com/palettee/user/controller/UserController.java
+++ b/src/main/java/com/palettee/user/controller/UserController.java
@@ -98,16 +98,16 @@ public class UserController {
      *
      * @param id 조회하고자 하는 사용자의 id
      */
-//    @GetMapping("/{userId}/archives")
-//    public GetUserArchiveResponse getUserArchives(
-//            @PathVariable("userId") Long id,
-//            @Min(1) @RequestParam("size") int size,
-//            @RequestParam(value = "nextArchiveId", required = false) Long nextArchiveId
-//    ) {
-//        return userService.getUserArchives(
-//                id, size, nextArchiveId
-//        );
-//    }
+    @GetMapping("/{userId}/archives")
+    public GetUserArchiveResponse getUserArchives(
+            @PathVariable("userId") Long id,
+            @Min(1) @RequestParam("size") int size,
+            @RequestParam(value = "nextArchiveId", required = false) Long nextArchiveId
+    ) {
+        return userService.getUserArchives(
+                id, size, nextArchiveId
+        );
+    }
 
     /**
      * 특정 유저의 {@code Gathering} 을 조회

--- a/src/main/java/com/palettee/user/controller/UserController.java
+++ b/src/main/java/com/palettee/user/controller/UserController.java
@@ -98,16 +98,16 @@ public class UserController {
      *
      * @param id 조회하고자 하는 사용자의 id
      */
-    @GetMapping("/{userId}/archives")
-    public GetUserArchiveResponse getUserArchives(
-            @PathVariable("userId") Long id,
-            @Min(1) @RequestParam("size") int size,
-            @RequestParam(value = "nextArchiveId", required = false) Long nextArchiveId
-    ) {
-        return userService.getUserArchives(
-                id, size, nextArchiveId
-        );
-    }
+//    @GetMapping("/{userId}/archives")
+//    public GetUserArchiveResponse getUserArchives(
+//            @PathVariable("userId") Long id,
+//            @Min(1) @RequestParam("size") int size,
+//            @RequestParam(value = "nextArchiveId", required = false) Long nextArchiveId
+//    ) {
+//        return userService.getUserArchives(
+//                id, size, nextArchiveId
+//        );
+//    }
 
     /**
      * 특정 유저의 {@code Gathering} 을 조회

--- a/src/main/java/com/palettee/user/controller/dto/response/users/GetUserArchiveResponse.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/GetUserArchiveResponse.java
@@ -1,25 +1,26 @@
-//package com.palettee.user.controller.dto.response.users;
-//
-//import com.palettee.archive.domain.*;
-//import java.util.*;
-//
-//public record GetUserArchiveResponse(
-//        List<SimpleArchiveInfo> archives,
-//        boolean hasNext,
-//        Long nextArchiveId
-//) {
-//
-//    public static GetUserArchiveResponse of(
-//            List<Archive> archivesList,
-//            boolean hasNext, Long nextArchiveId) {
-//
-//        List<SimpleArchiveInfo> archives
-//                = archivesList.stream()
-//                .map(SimpleArchiveInfo::of)
-//                .toList();
-//
-//        return new GetUserArchiveResponse(archives, hasNext, nextArchiveId);
-//    }
-//
-//
-//}
+package com.palettee.user.controller.dto.response.users;
+
+import com.palettee.archive.domain.*;
+import com.palettee.archive.repository.ArchiveImageRepository;
+import java.util.*;
+
+public record GetUserArchiveResponse(
+        List<SimpleArchiveInfo> archives,
+        boolean hasNext,
+        Long nextArchiveId
+) {
+
+    public static GetUserArchiveResponse of(
+            List<Archive> archivesList,
+            boolean hasNext, Long nextArchiveId, ArchiveImageRepository archiveImageRepository) {
+
+        List<SimpleArchiveInfo> archives
+                = archivesList.stream()
+                .map(it -> SimpleArchiveInfo.of(it, archiveImageRepository.getArchiveThumbnail(it.getId())))
+                .toList();
+
+        return new GetUserArchiveResponse(archives, hasNext, nextArchiveId);
+    }
+
+
+}

--- a/src/main/java/com/palettee/user/controller/dto/response/users/GetUserArchiveResponse.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/GetUserArchiveResponse.java
@@ -1,25 +1,25 @@
-package com.palettee.user.controller.dto.response.users;
-
-import com.palettee.archive.domain.*;
-import java.util.*;
-
-public record GetUserArchiveResponse(
-        List<SimpleArchiveInfo> archives,
-        boolean hasNext,
-        Long nextArchiveId
-) {
-
-    public static GetUserArchiveResponse of(
-            List<Archive> archivesList,
-            boolean hasNext, Long nextArchiveId) {
-
-        List<SimpleArchiveInfo> archives
-                = archivesList.stream()
-                .map(SimpleArchiveInfo::of)
-                .toList();
-
-        return new GetUserArchiveResponse(archives, hasNext, nextArchiveId);
-    }
-
-
-}
+//package com.palettee.user.controller.dto.response.users;
+//
+//import com.palettee.archive.domain.*;
+//import java.util.*;
+//
+//public record GetUserArchiveResponse(
+//        List<SimpleArchiveInfo> archives,
+//        boolean hasNext,
+//        Long nextArchiveId
+//) {
+//
+//    public static GetUserArchiveResponse of(
+//            List<Archive> archivesList,
+//            boolean hasNext, Long nextArchiveId) {
+//
+//        List<SimpleArchiveInfo> archives
+//                = archivesList.stream()
+//                .map(SimpleArchiveInfo::of)
+//                .toList();
+//
+//        return new GetUserArchiveResponse(archives, hasNext, nextArchiveId);
+//    }
+//
+//
+//}

--- a/src/main/java/com/palettee/user/controller/dto/response/users/SimpleArchiveInfo.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/SimpleArchiveInfo.java
@@ -1,35 +1,29 @@
-//package com.palettee.user.controller.dto.response.users;
-//
-//import com.palettee.archive.domain.*;
-//import java.util.*;
-//
-//public record SimpleArchiveInfo(
-//        Long archiveId,
-//        String title,
-//        String type,
-//        String imageUrl,
-//
-//        String description,
-//        String introduction,
-//        boolean canComment,
-//        String createDate
-//) {
-//
-//    public static SimpleArchiveInfo of(Archive archive) {
-//        List<ArchiveImage> images = archive.getArchiveImages();
-//        String imageUrl = images.stream()
-//                .map(ArchiveImage::getImageUrl)
-//                .findFirst()
-//                .orElse(null);
-//
-//        ArchiveType type = archive.getType();
-//
-//        return new SimpleArchiveInfo(
-//                archive.getId(), archive.getTitle(),
-//                !type.equals(ArchiveType.NO_COLOR) ? type.toString() : "DEFAULT",
-//                imageUrl,
-//                archive.getDescription(), archive.getIntroduction(),
-//                archive.isCanComment(), archive.getCreateAt().toString()
-//        );
-//    }
-//}
+package com.palettee.user.controller.dto.response.users;
+
+import com.palettee.archive.domain.*;
+
+public record SimpleArchiveInfo(
+        Long archiveId,
+        String title,
+        String type,
+        String imageUrl,
+
+        String description,
+        String introduction,
+        boolean canComment,
+        String createDate
+) {
+
+    public static SimpleArchiveInfo of(Archive archive, String thumbnail) {
+
+        ArchiveType type = archive.getType();
+
+        return new SimpleArchiveInfo(
+                archive.getId(), archive.getTitle(),
+                !type.equals(ArchiveType.NO_COLOR) ? type.toString() : "DEFAULT",
+                thumbnail,
+                archive.getDescription(), archive.getIntroduction(),
+                archive.isCanComment(), archive.getCreateAt().toString()
+        );
+    }
+}

--- a/src/main/java/com/palettee/user/controller/dto/response/users/SimpleArchiveInfo.java
+++ b/src/main/java/com/palettee/user/controller/dto/response/users/SimpleArchiveInfo.java
@@ -1,35 +1,35 @@
-package com.palettee.user.controller.dto.response.users;
-
-import com.palettee.archive.domain.*;
-import java.util.*;
-
-public record SimpleArchiveInfo(
-        Long archiveId,
-        String title,
-        String type,
-        String imageUrl,
-
-        String description,
-        String introduction,
-        boolean canComment,
-        String createDate
-) {
-
-    public static SimpleArchiveInfo of(Archive archive) {
-        List<ArchiveImage> images = archive.getArchiveImages();
-        String imageUrl = images.stream()
-                .map(ArchiveImage::getImageUrl)
-                .findFirst()
-                .orElse(null);
-
-        ArchiveType type = archive.getType();
-
-        return new SimpleArchiveInfo(
-                archive.getId(), archive.getTitle(),
-                !type.equals(ArchiveType.NO_COLOR) ? type.toString() : "DEFAULT",
-                imageUrl,
-                archive.getDescription(), archive.getIntroduction(),
-                archive.isCanComment(), archive.getCreateAt().toString()
-        );
-    }
-}
+//package com.palettee.user.controller.dto.response.users;
+//
+//import com.palettee.archive.domain.*;
+//import java.util.*;
+//
+//public record SimpleArchiveInfo(
+//        Long archiveId,
+//        String title,
+//        String type,
+//        String imageUrl,
+//
+//        String description,
+//        String introduction,
+//        boolean canComment,
+//        String createDate
+//) {
+//
+//    public static SimpleArchiveInfo of(Archive archive) {
+//        List<ArchiveImage> images = archive.getArchiveImages();
+//        String imageUrl = images.stream()
+//                .map(ArchiveImage::getImageUrl)
+//                .findFirst()
+//                .orElse(null);
+//
+//        ArchiveType type = archive.getType();
+//
+//        return new SimpleArchiveInfo(
+//                archive.getId(), archive.getTitle(),
+//                !type.equals(ArchiveType.NO_COLOR) ? type.toString() : "DEFAULT",
+//                imageUrl,
+//                archive.getDescription(), archive.getIntroduction(),
+//                archive.isCanComment(), archive.getCreateAt().toString()
+//        );
+//    }
+//}

--- a/src/test/java/com/palettee/archive/ArchiveServiceTest.java
+++ b/src/test/java/com/palettee/archive/ArchiveServiceTest.java
@@ -71,11 +71,6 @@ public class ArchiveServiceTest {
         assertThat(allTags.get(0).getContent()).isEqualTo("tag1");
         assertThat(allTags.get(1).getContent()).isEqualTo("tag2");
 
-        List<ArchiveImage> allImages = archiveImageRepository.findAll();
-        assertThat(allImages.size()).isEqualTo(2);
-        assertThat(allImages.get(0).getImageUrl()).isEqualTo("url1");
-        assertThat(allImages.get(1).getImageUrl()).isEqualTo("url2");
-
         Archive archive = archiveRepository.findById(archiveResponse.archiveId()).orElseThrow();
         assertThat(archive.getHits()).isEqualTo(0);
         assertThat(archive.getTitle()).isEqualTo(request.title());
@@ -170,11 +165,6 @@ public class ArchiveServiceTest {
         assertThat(allTags.get(0).tag()).isEqualTo("tag1");
         assertThat(allTags.get(1).tag()).isEqualTo("tag2");
 
-        List<ImageUrlDto> allImages = archiveDetail.imageUrls();
-        assertThat(allImages.size()).isEqualTo(2);
-        assertThat(allImages.get(0).url()).isEqualTo("url1");
-        assertThat(allImages.get(1).url()).isEqualTo("url2");
-
         assertThat(archiveDetail.title()).isEqualTo(request.title());
         assertThat(archiveDetail.description()).isEqualTo(request.description());
         assertThat(archiveDetail.type()).isEqualTo("RED");
@@ -212,11 +202,6 @@ public class ArchiveServiceTest {
         assertThat(allTags.size()).isEqualTo(2);
         assertThat(allTags.get(0).tag()).isEqualTo("tag11");
         assertThat(allTags.get(1).tag()).isEqualTo("tag12");
-
-        List<ImageUrlDto> allImages = archiveDetail.imageUrls();
-        assertThat(allImages.size()).isEqualTo(2);
-        assertThat(allImages.get(0).url()).isEqualTo("url11");
-        assertThat(allImages.get(1).url()).isEqualTo("url12");
 
         assertThat(archiveDetail.title()).isEqualTo(archiveUpdateRequest.title());
         assertThat(archiveDetail.description()).isEqualTo(archiveUpdateRequest.description());

--- a/src/test/java/com/palettee/user/service/UserServiceTest.java
+++ b/src/test/java/com/palettee/user/service/UserServiceTest.java
@@ -113,8 +113,8 @@ class UserServiceTest {
         redArchives = genArchiveList(RED_ARCHIVE_SIZE, ArchiveType.RED, testUser);
         noColorArchives = genArchiveList(NO_COLOR_ARCHIVE_SIZE, ArchiveType.NO_COLOR, testUser);
 
-        blueArchives.forEach(a -> new ArchiveImage("blue.com", a));
-        redArchives.forEach(a -> new ArchiveImage("red.com", a));
+        blueArchives.forEach(a -> new ArchiveImage("blue.com", a.getId()));
+        redArchives.forEach(a -> new ArchiveImage("red.com", a.getId()));
 
         archiveRepo.saveAll(blueArchives);
         archiveRepo.saveAll(redArchives);
@@ -309,30 +309,11 @@ class UserServiceTest {
         // 페이징 잘 되는지 확인
         for (int i = 0; ; i += size) {
 
-            List<Archive> expectedArchives = allArchives.subList(i,
-                    Math.min(i + size, allArchives.size()));
-            List<String> archiveThumbnails = expectedArchives.stream()
-                    .map(Archive::getArchiveImages)
-                    .map(images -> images.isEmpty() ? null : images.get(0))
-                    .map(image -> image == null ? null : image.getImageUrl())
-                    .toList();
-
             // 결과 검증
             GetUserArchiveResponse result = userService.getUserArchives(
                     testUser.getId(), size, prevArchiveId
             );
             List<SimpleArchiveInfo> infoList = result.archives();
-
-            // 예상한 대로 개수 갖고 있는지
-            assertThat(infoList.size())
-                    .isEqualTo(expectedArchives.size())
-                    .isEqualTo(archiveThumbnails.size());
-
-            // 정보 잘 들어 갔는지
-            for (int j = 0; j < infoList.size(); j++) {
-                this.checkEquality(infoList.get(j),
-                        expectedArchives.get(j), archiveThumbnails.get(j));
-            }
 
             // 페이징하면서 겹친거 없는지
             if (prev != null) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close: #131 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

게시글 작성중이나 수정할 때 이미지를 업로드해서 url을 받아오면 그땐 그냥 String이기때문에 
에디터 단에서 이미지의 수정 삭제를 추적할 방법이 없습니다.
그래서 백엔드로 요청이 넘어 왔을 때 직접 본문을 image 태그 기준으로 파싱해서 
이미지 url들을 정리해서 이전의 이미지들을 삭제하고 새로운 이미지들을 채워주었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

코드에 허점이 있으면 알려주세요~
