### PR TITLE
#125 - 채팅, 채팅방 관련 전체적인 로직 변경

### DIFF
--- a/src/main/java/com/palettee/chat/controller/dto/response/ChatCustomResponse.java
+++ b/src/main/java/com/palettee/chat/controller/dto/response/ChatCustomResponse.java
@@ -18,23 +18,21 @@ public class ChatCustomResponse {
 
     private LocalDateTime lastSendAt;
 
-    public static ChatCustomResponse toResponseFromEntity(List<Chat> chats, boolean hasNext,
-                                                LocalDateTime nextChatTimeStamp) {
+    public static ChatCustomResponse toResponseFromEntity(List<Chat> chats, boolean hasNext) {
         return new ChatCustomResponse(
                 chats.stream()
                         .map(ChatResponse::toResponseFromEntity)
                         .toList(),
                 hasNext,
-                nextChatTimeStamp
+                null
         );
     }
 
-    public static ChatCustomResponse toResponseFromDto(List<ChatResponse> chats, boolean hasNext,
-                                                LocalDateTime nextChatTimeStamp) {
+    public static ChatCustomResponse toResponseFromDto(List<ChatResponse> chats, boolean hasNext) {
         return new ChatCustomResponse(
                 chats,
                 hasNext,
-                nextChatTimeStamp
+                hasNext ? chats.get(chats.size() - 1).getSendAt() : null
         );
     }
 }

--- a/src/main/java/com/palettee/chat/domain/ChatUser.java
+++ b/src/main/java/com/palettee/chat/domain/ChatUser.java
@@ -23,9 +23,21 @@ public class ChatUser {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
     @Builder
-    public ChatUser(ChatRoom chatRoom, User user) {
+    public ChatUser(ChatRoom chatRoom, User user, boolean isDeleted) {
         this.chatRoom = chatRoom;
         this.user = user;
+        this.isDeleted = isDeleted;
+    }
+
+    public void participation() {
+        this.isDeleted = true;
+    }
+
+    public void leave() {
+        this.isDeleted = false;
     }
 }

--- a/src/main/java/com/palettee/chat/repository/ChatCustomRepositoryImpl.java
+++ b/src/main/java/com/palettee/chat/repository/ChatCustomRepositoryImpl.java
@@ -38,15 +38,10 @@ public class ChatCustomRepositoryImpl implements ChatCustomRepository{
                 .fetch();
 
         boolean hasNext = chats.size() > size;
-
-        LocalDateTime lastSendAt = null;
         if(hasNext) {
-            if(size != 0) {
-                lastSendAt = chats.get(size-1).getSendAt();
-            }
             chats = chats.subList(0, size);
         }
 
-        return ChatCustomResponse.toResponseFromEntity(chats, hasNext, lastSendAt);
+        return ChatCustomResponse.toResponseFromEntity(chats, hasNext);
     }
 }

--- a/src/main/java/com/palettee/chat/repository/ChatImageRepository.java
+++ b/src/main/java/com/palettee/chat/repository/ChatImageRepository.java
@@ -1,9 +1,12 @@
 package com.palettee.chat.repository;
 
 import com.palettee.chat.domain.*;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.*;
 
-public interface ChatImageRepository
-        extends JpaRepository<ChatImage, Long> {
-
+public interface ChatImageRepository extends JpaRepository<ChatImage, Long> {
+    @Modifying
+    @Query("DELETE FROM ChatImage ci WHERE ci.chat IN (SELECT c FROM Chat c WHERE c.chatRoom.id = :chatRoomId)")
+    void bulkDeleteChatImagesByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }
+

--- a/src/main/java/com/palettee/chat/repository/ChatRepository.java
+++ b/src/main/java/com/palettee/chat/repository/ChatRepository.java
@@ -2,6 +2,12 @@ package com.palettee.chat.repository;
 
 import com.palettee.chat.domain.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRepository extends JpaRepository<Chat, Long>, ChatCustomRepository {
+    @Modifying
+    @Query("delete from Chat c where c.chatRoom.id = :chatRoomId")
+    void bulkDeleteChatsByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/palettee/chat/repository/ChatUserRepository.java
+++ b/src/main/java/com/palettee/chat/repository/ChatUserRepository.java
@@ -1,13 +1,32 @@
 package com.palettee.chat.repository;
 
 import com.palettee.chat.domain.*;
-import com.palettee.chat_room.domain.ChatRoom;
 import com.palettee.user.domain.User;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
-    Optional<ChatUser> findByChatRoomAndUser(ChatRoom chatRoom, User user);
-    boolean existsByChatRoomAndUser(ChatRoom chatRoom, User user);
+    @Query("SELECT cu from ChatUser cu " +
+            "WHERE cu.chatRoom.id = :chatRoomId " +
+            "AND cu.user.id = :userId " +
+            "AND cu.isDeleted = :isDeleted ")
+    Optional<ChatUser> findByChatRoomAndUser(@Param("chatRoomId") Long chatRoomId,
+                                             @Param("userId") Long userId,
+                                             @Param("isDeleted") boolean isDeleted);
+
+    @Query("SELECT count(cu) from ChatUser cu WHERE cu.chatRoom.id = :chatRoomId And cu.isDeleted = :isDeleted")
+    int countChatUsersByChatRoom(@Param("chatRoomId") Long chatRoomId,
+                                 @Param("isDeleted") boolean isDeleted);
+
+    @Modifying
+    @Query("delete from ChatUser cu where cu.chatRoom.id = :chatRoomId")
+    void deleteAllByChatRoomId(@Param("chatRoomId") Long chatRoomId);
+
+    @Query("select cu from ChatUser cu join fetch cu.user where cu.chatRoom in " +
+            "(select cu2.chatRoom from ChatUser cu2 where cu2.user = :user)" +
+            "and cu.user <> :user")
+    List<ChatUser> getChatUsersByMe(@Param("user") User user);
 }

--- a/src/main/java/com/palettee/chat/service/ChatImageService.java
+++ b/src/main/java/com/palettee/chat/service/ChatImageService.java
@@ -18,4 +18,8 @@ public class ChatImageService {
     public List<ChatImage> saveChatImages(List<ChatImage> chatImages) {
         return chatImageRepository.saveAll(chatImages);
     }
+
+    public void deleteChatImages(Long chatRoomId) {
+        chatImageRepository.bulkDeleteChatImagesByChatRoomId(chatRoomId);
+    }
 }

--- a/src/main/java/com/palettee/chat/service/ChatRedisService.java
+++ b/src/main/java/com/palettee/chat/service/ChatRedisService.java
@@ -4,7 +4,6 @@ import com.palettee.chat.controller.dto.request.ChatRequest;
 import com.palettee.chat.controller.dto.response.ChatCustomResponse;
 import com.palettee.chat.controller.dto.response.ChatResponse;
 import com.palettee.chat.repository.ChatRepository;
-import com.palettee.chat_room.service.ChatRoomService;
 import com.palettee.global.redis.utils.TypeConverter;
 import com.palettee.user.domain.User;
 import com.palettee.user.exception.UserNotFoundException;
@@ -22,6 +21,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.palettee.global.Const.*;
+
 @Repository
 @Slf4j
 public class ChatRedisService {
@@ -29,19 +30,15 @@ public class ChatRedisService {
     private final RedisTemplate<String, ChatResponse> redisTemplate;
     private final ChatRepository chatRepository;
     private final UserRepository userRepository;
-    private final ChatRoomService chatRoomService;
     private ZSetOperations<String, ChatResponse> zSetOperations;
-    private static final String NEW_CHAT = "NEW_CHAT";
 
     public ChatRedisService(
             @Qualifier("chatRedisTemplate") RedisTemplate<String, ChatResponse> redisTemplate,
             ChatRepository chatRepository,
-            UserRepository userRepository,
-            ChatRoomService chatRoomService) {
+            UserRepository userRepository) {
         this.redisTemplate = redisTemplate;
         this.chatRepository = chatRepository;
         this.userRepository = userRepository;
-        this.chatRoomService = chatRoomService;
     }
 
     @PostConstruct
@@ -51,59 +48,63 @@ public class ChatRedisService {
 
     public ChatResponse addChat(String email, Long chatRoomId, ChatRequest chatRequest) {
         User user = getUser(email);
-        chatRoomService.getChatRoom(chatRoomId);
 
         ChatResponse chatResponse = ChatResponse.toResponse(chatRoomId, user, chatRequest);
-        log.info("save chat sendAt = {}", chatResponse.getSendAt());
-        LocalDateTime sendAt = chatResponse.getSendAt();
+        String key = CHATROOM_KEY_PREFIX + TypeConverter.LongToString(chatResponse.getChatRoomId());
+        double score = TypeConverter.LocalDateTimeToDouble(chatResponse.getSendAt());
 
         redisTemplate
                 .opsForZSet()
-                .add(TypeConverter.LongToString(chatResponse.getChatRoomId()), chatResponse, TypeConverter.LocalDateTimeToDouble(sendAt));
+                .add(key, chatResponse, score);
+
+        Long size = redisTemplate.opsForZSet().size(key);
+        if (size != null && size > CHAT_MAX_SIZE) {
+            redisTemplate.opsForZSet().removeRange(key, 0, 0);
+        }
 
         redisTemplate
                 .opsForZSet()
-                .add(NEW_CHAT, chatResponse, TypeConverter.LocalDateTimeToDouble(sendAt));
+                .add(NEW_CHAT, chatResponse, score);
 
-        redisTemplate.expire(TypeConverter.LongToString(chatResponse.getChatRoomId()), Duration.ofDays(1));
+        redisTemplate.expire(key, Duration.ofDays(1));
         return chatResponse;
     }
 
     public ChatCustomResponse getChats(Long chatRoomId, int size, LocalDateTime lastSendAt) {
-        String chatRoomIdStr = TypeConverter.LongToString(chatRoomId);
-
+        String key = CHATROOM_KEY_PREFIX + TypeConverter.LongToString(chatRoomId);
         long offset = 0;
         LocalDateTime findSendAt = lastSendAt;
 
         if (lastSendAt == null) {
-            log.info("Local = {}",LocalDateTime.now());
             findSendAt = LocalDateTime.now();
         } else {
             offset = 1;
         }
 
         Double cursor = TypeConverter.LocalDateTimeToDouble(findSendAt);
-        log.info("cursor = {}", cursor);
         Set<ChatResponse> objects
-                = zSetOperations.reverseRangeByScore(chatRoomIdStr, Double.NEGATIVE_INFINITY, cursor, offset, size+1);
+                = zSetOperations.reverseRangeByScore(key, Double.NEGATIVE_INFINITY, cursor, offset, size+1);
         List<ChatResponse> results = objects.stream().collect(Collectors.toList());
 
-        log.info("results size = {}", results.size());
+        redisTemplate.expire(key, Duration.ofDays(1));
 
+        // size와 작거나 같으면 DB에서 조회
         if(results.size() <= size) {
+            // 부족한 데이터 만큼 DB에서 조회
             ChatCustomResponse chatDataInDB = findOtherChatDataInDB(results, lastSendAt, chatRoomId, size - results.size());
 
-            if(!results.isEmpty()) {
-                results.addAll(chatDataInDB.getChats());
-                return ChatCustomResponse.toResponseFromDto(results, chatDataInDB.isHasNext(), chatDataInDB.getLastSendAt());
+            // DB에서 조회한 데이터가 존재하면 Redis에 데이터를 넣는다.
+            if (!chatDataInDB.getChats().isEmpty()) {
+                Long redisTotalSize = redisTemplate.opsForZSet().size(key);
+                cachingDBDataToRedis(redisTotalSize, chatDataInDB.getChats());
             }
 
-            return chatDataInDB;
+            // DB에서 조회한 데이터 list를 Redis에서 조회한 데이터 list와 합친다.
+            results.addAll(chatDataInDB.getChats());
+            return ChatCustomResponse.toResponseFromDto(results, chatDataInDB.isHasNext());
         }
 
-        LocalDateTime nextSendAt = results.get(size - 1).getSendAt();
-        List<ChatResponse> chats = results.subList(0, size);
-        return ChatCustomResponse.toResponseFromDto(chats, true, nextSendAt);
+        return ChatCustomResponse.toResponseFromDto(results.subList(0, size), true);
     }
 
     public ChatCustomResponse findOtherChatDataInDB(List<ChatResponse> results, LocalDateTime lastSendAt,
@@ -111,20 +112,21 @@ public class ChatRedisService {
         if(!results.isEmpty()) {
             lastSendAt = results.get(results.size() - 1).getSendAt();
         }
-        ChatCustomResponse chatNoOffset = chatRepository.findChatNoOffset(chatRoomId, size, lastSendAt);
-
-        if (!chatNoOffset.getChats().isEmpty()) {
-            cachingDBDataToRedis(chatNoOffset.getChats());
-        }
-        return chatNoOffset;
+        return chatRepository.findChatNoOffset(chatRoomId, size, lastSendAt);
     }
 
-    public void cachingDBDataToRedis(List<ChatResponse> chatsInDB) {
-        for(ChatResponse chatResponse : chatsInDB) {
-            LocalDateTime sendAt = chatResponse.getSendAt();
+    // 허용 가능한 만큼만 Redis에 넣는다.
+    public void cachingDBDataToRedis(Long redisTotalSize, List<ChatResponse> chatsInDB) {
+        long possibleSize = CHAT_MAX_SIZE - redisTotalSize;
+        for(int i = 0; i < possibleSize; i++) {
+            ChatResponse chatResponse = chatsInDB.get(i);
             redisTemplate
                     .opsForZSet()
-                    .add(TypeConverter.LongToString(chatResponse.getChatRoomId()), chatResponse, TypeConverter.LocalDateTimeToDouble(sendAt));
+                    .add(TypeConverter.LongToString(chatResponse.getChatRoomId()),
+                            chatResponse, TypeConverter.LocalDateTimeToDouble(chatResponse.getSendAt()));
+            if(i == chatsInDB.size() - 1) {
+                break;
+            }
         }
     }
 

--- a/src/main/java/com/palettee/chat/service/ChatService.java
+++ b/src/main/java/com/palettee/chat/service/ChatService.java
@@ -1,0 +1,17 @@
+package com.palettee.chat.service;
+
+import com.palettee.chat.repository.ChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+    private final ChatRepository chatRepository;
+
+    public void deleteChats(Long chatRoomId) {
+        chatRepository.bulkDeleteChatsByChatRoomId(chatRoomId);
+    }
+}

--- a/src/main/java/com/palettee/chat/service/ChatUserService.java
+++ b/src/main/java/com/palettee/chat/service/ChatUserService.java
@@ -9,36 +9,42 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ChatUserService {
     private final ChatUserRepository chatUserRepository;
 
-    public void saveChatUser(ChatRoom chatRoom, User user) {
-        ChatUser chatUser = makeChatUser(chatRoom, user);
+    public void saveChatUser(ChatRoom chatRoom, User user, boolean isDeleted) {
+        ChatUser chatUser = makeChatUser(chatRoom, user, isDeleted);
         chatUserRepository.save(chatUser);
     }
 
-    public void deleteChatUser(ChatRoom chatRoom, User user) {
-        ChatUser chatUser = getChatUser(chatRoom, user);
-        chatUserRepository.delete(chatUser);
+    public void deleteChatUsers(Long chatRoomId) {
+        chatUserRepository.deleteAllByChatRoomId(chatRoomId);
     }
 
-    public boolean isExist(ChatRoom chatRoom, User user) {
-        return chatUserRepository.existsByChatRoomAndUser(chatRoom, user);
+    public int countChatRoom(Long chatRoomId) {
+        return chatUserRepository.countChatUsersByChatRoom(chatRoomId, true);
     }
 
-    private ChatUser makeChatUser(ChatRoom chatRoom, User user) {
+    public ChatUser getChatUser(Long chatRoomId, Long userId, boolean isDeleted) {
+        return chatUserRepository
+                .findByChatRoomAndUser(chatRoomId, userId, isDeleted)
+                .orElseThrow(() -> ChatUserNotFoundException.EXCEPTION);
+    }
+
+    public List<ChatUser> getMyChatUsers(User user) {
+        return chatUserRepository.getChatUsersByMe(user);
+    }
+
+    private ChatUser makeChatUser(ChatRoom chatRoom, User user, boolean isDeleted) {
         return ChatUser.builder()
                 .chatRoom(chatRoom)
                 .user(user)
+                .isDeleted(isDeleted)
                 .build();
-    }
-
-    private ChatUser getChatUser(ChatRoom chatRoom, User user) {
-        return chatUserRepository
-                .findByChatRoomAndUser(chatRoom, user)
-                .orElseThrow(() -> ChatUserNotFoundException.EXCEPTION);
     }
 }

--- a/src/main/java/com/palettee/chat_room/controller/ChatRoomController.java
+++ b/src/main/java/com/palettee/chat_room/controller/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.palettee.chat_room.controller;
 import com.palettee.chat.controller.dto.response.ChatCustomResponse;
 import com.palettee.chat.service.ChatRedisService;
 import com.palettee.chat_room.controller.dto.request.ChatRoomCreateRequest;
+import com.palettee.chat_room.controller.dto.response.ChatRoomListResponse;
 import com.palettee.chat_room.controller.dto.response.ChatRoomResponse;
 import com.palettee.chat_room.service.ChatRoomService;
 import com.palettee.global.security.validation.UserUtils;
@@ -27,7 +28,6 @@ public class ChatRoomController {
         return chatRoomService.saveChatRoom(chatRoomCreateRequest, contextUser);
     }
 
-    // userId는 추후에 삭제할 예정
     // 채팅방 참여
     @PostMapping("/participation/{chatRoomId}")
     public void participateChatRoom(@PathVariable Long chatRoomId) {
@@ -35,7 +35,6 @@ public class ChatRoomController {
         chatRoomService.participation(chatRoomId, contextUser);
     }
 
-    // userId는 추후에 삭제할 예정
     // 채팅방 나가기
     @DeleteMapping("/leave/{chatRoomId}")
     public void leaveChatRoom(@PathVariable Long chatRoomId) {
@@ -48,5 +47,11 @@ public class ChatRoomController {
                                        @RequestParam(value = "size") int size,
                                        @RequestParam(value = "lastSendAt", required = false) LocalDateTime lastSendAt) {
         return chatRedisService.getChats(chatRoomId, size, lastSendAt);
+    }
+
+    @GetMapping("/me")
+    public ChatRoomListResponse getMyChatRooms() {
+        User contextUser = UserUtils.getContextUser();
+        return chatRoomService.getMyChatRooms(contextUser);
     }
 }

--- a/src/main/java/com/palettee/chat_room/controller/dto/response/ChatRoomInfoResponse.java
+++ b/src/main/java/com/palettee/chat_room/controller/dto/response/ChatRoomInfoResponse.java
@@ -1,0 +1,19 @@
+package com.palettee.chat_room.controller.dto.response;
+
+import com.palettee.chat.domain.ChatUser;
+
+public record ChatRoomInfoResponse(
+        Long chatRoomId,
+        Long userId,
+        String username,
+        String profileImg
+) {
+    public static ChatRoomInfoResponse toResponse(ChatUser chatUser) {
+        return new ChatRoomInfoResponse(
+                chatUser.getChatRoom().getId(),
+                chatUser.getUser().getId(),
+                chatUser.getUser().getName(),
+                chatUser.getUser().getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/palettee/chat_room/controller/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/palettee/chat_room/controller/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,17 @@
+package com.palettee.chat_room.controller.dto.response;
+
+import com.palettee.chat.domain.ChatUser;
+
+import java.util.List;
+
+public record ChatRoomListResponse(
+        List<ChatRoomInfoResponse> chatRooms
+) {
+    public static ChatRoomListResponse toResponse(List<ChatUser> chatUsers) {
+        return new ChatRoomListResponse(
+                chatUsers
+                        .stream()
+                        .map(ChatRoomInfoResponse::toResponse)
+                        .toList());
+    }
+}

--- a/src/main/java/com/palettee/chat_room/domain/ChatCategory.java
+++ b/src/main/java/com/palettee/chat_room/domain/ChatCategory.java
@@ -3,7 +3,7 @@ package com.palettee.chat_room.domain;
 public enum ChatCategory {
     COFFEE_CHAT,
     MENTORING,
-    QNA,
-    NETWORKING,
+    FEEDBACK,
+    GATHERING,
     ECT
 }

--- a/src/main/java/com/palettee/chat_room/repository/ChatRoomRepository.java
+++ b/src/main/java/com/palettee/chat_room/repository/ChatRoomRepository.java
@@ -1,7 +1,13 @@
 package com.palettee.chat_room.repository;
 
 import com.palettee.chat_room.domain.ChatRoom;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    @Modifying
+    @Query("delete from ChatRoom cr where cr.id = :chatRoomId")
+    void deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/palettee/global/Const.java
+++ b/src/main/java/com/palettee/global/Const.java
@@ -1,6 +1,6 @@
 package com.palettee.global;
 
-public  class Const {
+public class Const {
 
     public static final String VIEW_PREFIX = "View_";
 
@@ -10,4 +10,9 @@ public  class Const {
 
     public static int gathering_Page_Size;
 
+    public static final String NEW_CHAT = "NEW_CHAT";
+
+    public static final Long CHAT_MAX_SIZE = 100L;
+
+    public static final String CHATROOM_KEY_PREFIX = "CHATROOM_";
 }

--- a/src/main/java/com/palettee/global/handler/StompHandler.java
+++ b/src/main/java/com/palettee/global/handler/StompHandler.java
@@ -145,10 +145,7 @@ public class StompHandler implements ChannelInterceptor {
         String chatRoomId = destination.substring(TOPIC_CHAT_ENDPOINT.length());
         ChatRoom chatRoom = chatRoomService.getChatRoom(Long.valueOf(chatRoomId));
 
-        if(!chatUserService.isExist(chatRoom, user)) {
-            log.error("해당 채팅방에 참여자가 아닙니다.");
-            throw ChatUserNotFoundException.EXCEPTION;
-        }
+        chatUserService.getChatUser(chatRoom.getId(), user.getId(), true);
     }
 
     private User getUser(String email) {

--- a/src/test/java/com/palettee/chat/ChatRedisServiceTest.java
+++ b/src/test/java/com/palettee/chat/ChatRedisServiceTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static com.palettee.global.Const.*;
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
@@ -74,7 +75,7 @@ public class ChatRedisServiceTest {
         chatRoomRepository.deleteAll();
         chatRepository.deleteAll();
 
-        redisTemplate.delete(String.valueOf(savedChatRoom.getId()));
+        redisTemplate.delete(CHATROOM_KEY_PREFIX + String.valueOf(savedChatRoom.getId()));
     }
 
     @Test
@@ -89,7 +90,7 @@ public class ChatRedisServiceTest {
         // when
         ChatResponse chatResponse = chatRedisService.addChat(userEmail, chatRoomId, chatRequest);
         Double sendAt = TypeConverter.LocalDateTimeToDouble(chatResponse.getSendAt());
-        List<ChatResponse> results = zSetOperations.rangeByScore(String.valueOf(chatResponse.getChatRoomId()), sendAt, sendAt).stream().toList();
+        List<ChatResponse> results = zSetOperations.rangeByScore(CHATROOM_KEY_PREFIX + String.valueOf(chatResponse.getChatRoomId()), sendAt, sendAt).stream().toList();
 
         // then
         assertThat(results.size()).isEqualTo(1);


### PR DESCRIPTION
## #️⃣연관된 이슈
resolved : #125 

## 📝작업 내용
> 채팅이 Redis에 계속 쌓이게 되면 메모리 부하올 것을 고려하여 최신 채팅 데이터 100개만 Redis에 저장
> 채팅 상대방이 채팅방을 나가도 상대방의 이름, 프로필 이미지, id를 조회하기 위해 ChatUser에 isDeleted 컬럼을 추가하여 논리 삭제 진행(채팅방에 모두 나갔을 때 물리 삭제 진행)
> 내가 참여한 채팅방 목록 조회 API 구현

## 💬리뷰 요구사항(선택)
> Redis에 100개의 채팅을 저장하는 것이 적당할까요??
> Redis의 key마다 ttl 설정을 하루로 하여 채팅방 이용이 적은 채팅방의 채팅은 Redis에서 자동으로 삭제하게 하였습니다.
