### PR TITLE
#140 - 좋아요를 반복적으로 누를때 발생하는 중복 알림 방지 구현

### DIFF
--- a/src/main/java/com/palettee/notification/service/NotificationRedisService.java
+++ b/src/main/java/com/palettee/notification/service/NotificationRedisService.java
@@ -1,0 +1,37 @@
+package com.palettee.notification.service;
+
+import com.palettee.notification.controller.dto.NotificationRequest;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationRedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public boolean checkLikeNotification(NotificationRequest request) {
+        String redisKey = makeRedisKey(request);
+        Long result = redisTemplate.opsForSet()
+                .add(makeRedisKey(request), request.userId());
+
+        redisTemplate.expire(redisKey, 5, TimeUnit.SECONDS);
+
+        if (result == null) {
+            log.info("알수 없는 문제 발생입니다.");
+            return true;
+        }
+
+        return result != 1L;
+    }
+
+    private String makeRedisKey(NotificationRequest request) {
+        return "notification:" + request.likeType().name() + "-userId:" + request.userId() + "-contentId:"
+                + request.contentId();
+    }
+
+}

--- a/src/main/java/com/palettee/notification/service/NotificationService.java
+++ b/src/main/java/com/palettee/notification/service/NotificationService.java
@@ -28,6 +28,7 @@ public class NotificationService {
 
     private final EmitterRepository emitterRepository;
     private final NotificationRepository notificationRepository;
+    private final NotificationRedisService notificationRedisService;
 
     @Value("${sse.timeout}")
     private Long ONE_HOUR;
@@ -81,6 +82,11 @@ public class NotificationService {
 
     @Transactional
     public void send(NotificationRequest request) {
+
+        if (notificationRedisService.checkLikeNotification(request)) {
+            return;
+        }
+
         sendNotification(request, saveNotification(request));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

close: #140 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

좋아요를 반복적으로 눌면 좋아요고 걸리고 풀리고를 반복하며 중복 알림 계속 발생
좋아요 알림 전달시 정보를 5초간 레디스에 저장합니다. 
만약 반복해서 누르면 계속 5초가 갱싱되기 때문에 최소 5초간의 간격을 두고 눌러야 알림이 발생합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
